### PR TITLE
fence_scsi: status should return off if any device is off

### DIFF
--- a/fence/agents/scsi/fence_scsi.py
+++ b/fence/agents/scsi/fence_scsi.py
@@ -32,6 +32,9 @@ def get_status(conn, options):
 		else:
 			logging.debug("No registration for key "\
 				+ options["--key"] + " on device " + dev + "\n")
+			if options["--action"] == "on":
+				status = "off"
+				break
 	return status
 
 


### PR DESCRIPTION
As-is, get_status will return on if any device is on, with the result being that the library will choose to not attempt to unfence devices during an "on" action even if some devices need it.  This can be seen by adding a new device to the list and running "on", which will simply display "Success: Already ON".  We should return off if any device is off.  