### PR TITLE
fence_rhevm fixes

### DIFF
--- a/fence/agents/rhevm/fence_rhevm.py
+++ b/fence/agents/rhevm/fence_rhevm.py
@@ -87,7 +87,7 @@ def send_command(opt, command, method="GET"):
 	conn = pycurl.Curl()
 	web_buffer = StringIO.StringIO()
 	conn.setopt(pycurl.URL, url)
-	conn.setopt(pycurl.HTTPHEADER, ["Content-type: application/xml", "Accept: application/xml", "Prefer: persistent-auth"])
+	conn.setopt(pycurl.HTTPHEADER, ["Content-type: application/xml", "Accept: application/xml", "Prefer: persistent-auth", "Filter: true"])
 
 	if opt.has_key("cookie"):
 		conn.setopt(pycurl.COOKIE, opt["cookie"])

--- a/fence/agents/rhevm/fence_rhevm.py
+++ b/fence/agents/rhevm/fence_rhevm.py
@@ -66,7 +66,8 @@ def get_list(conn, options):
 		lines = res.split("<vm ")
 		for i in range(1, len(lines)):
 			name = RE_GET_NAME.search(lines[i]).group(1)
-			outlets[name] = ("", None)
+			status = RE_STATUS.search(lines[i]).group(1)
+			outlets[name] = ("", status)
 	except AttributeError:
 		return {}
 	except IndexError:


### PR DESCRIPTION
Hi,

Please consider pulling these fixes for the fence_rhevm agent.

Commit 03eee86 adds the Filter header to the curl command. Without this the user used to connect to oVirt/RHEV-M needs more privileges than the UserRole role. With the filter header set, the UserRole permissions are sufficient to make the fence agent work.

Commit d19bb9b fills in the status of the outlets to prevent a crash on the monitor action. This error only occurs when the list of vm's returned is non-empty (when a user with UserRole role is used).

Regards,

Rik
