### PR TITLE
fence_virsh: escape "EXPECT" string.

### DIFF
--- a/fence/agents/virsh/fence_virsh.py
+++ b/fence/agents/virsh/fence_virsh.py
@@ -74,7 +74,7 @@ def main():
 
 	all_opt["secure"]["default"] = "1"
 	all_opt["cmd_prompt"]["default"] = [r"\[EXPECT\]#\ "]
-	all_opt["ssh_options"]["default"] = "-t '/bin/bash -c \"" + r"PS1=\[EXPECT\]#\  " + "/bin/bash --noprofile --norc\"'"
+	all_opt["ssh_options"]["default"] = "-t '/bin/bash -c \"" + r"PS1=\\[EXPECT\\]#\  " + "/bin/bash --noprofile --norc\"'"
 
 	options = check_input(device_opt, process_input(device_opt))
 


### PR DESCRIPTION
Escape EXPECT string to prevent nroff error "warning: can't find special
character `EXPECT\'`"

Signed-off-by: Adrian Vondendriesch <adrian.vondendriesch@credativ.de>