### PR TITLE
Fixes for the pve fence agent

### DIFF
--- a/fence/agents/pve/fence_pve.py
+++ b/fence/agents/pve/fence_pve.py
@@ -106,11 +106,11 @@ def send_cmd(options, cmd, post=None):
 		conn.setopt(pycurl.POSTFIELDS, urllib.urlencode(post))
 	conn.setopt(pycurl.WRITEFUNCTION, output_buffer.write)
 	conn.setopt(pycurl.TIMEOUT, int(options["--shell-timeout"]))
-	if opt.has_key("--ssl") or opt.has_key("--ssl-secure"):
+	if options.has_key("--ssl") or opt.has_key("--ssl-secure"):
 		conn.setopt(pycurl.SSL_VERIFYPEER, 1)
 		conn.setopt(pycurl.SSL_VERIFYHOST, 2)
 
-	if opt.has_key("--ssl-insecure"):
+	if options.has_key("--ssl-insecure"):
 		conn.setopt(pycurl.SSL_VERIFYPEER, 0)
 		conn.setopt(pycurl.SSL_VERIFYHOST, 0)
 

--- a/fence/agents/pve/fence_pve.py
+++ b/fence/agents/pve/fence_pve.py
@@ -109,8 +109,7 @@ def send_cmd(options, cmd, post=None):
 	if options.has_key("--ssl") or opt.has_key("--ssl-secure"):
 		conn.setopt(pycurl.SSL_VERIFYPEER, 1)
 		conn.setopt(pycurl.SSL_VERIFYHOST, 2)
-
-	if options.has_key("--ssl-insecure"):
+	else:
 		conn.setopt(pycurl.SSL_VERIFYPEER, 0)
 		conn.setopt(pycurl.SSL_VERIFYHOST, 0)
 


### PR DESCRIPTION
A misspelled variable caused error messages.
Also we default now to SSL connections.