### PR TITLE
Default to SSL to comply with pve and fix typo

### DIFF
--- a/fence/agents/pve/fence_pve.py
+++ b/fence/agents/pve/fence_pve.py
@@ -106,11 +106,10 @@ def send_cmd(options, cmd, post=None):
 		conn.setopt(pycurl.POSTFIELDS, urllib.urlencode(post))
 	conn.setopt(pycurl.WRITEFUNCTION, output_buffer.write)
 	conn.setopt(pycurl.TIMEOUT, int(options["--shell-timeout"]))
-	if opt.has_key("--ssl") or opt.has_key("--ssl-secure"):
+	if options.has_key("--ssl") or options.has_key("--ssl-secure"):
 		conn.setopt(pycurl.SSL_VERIFYPEER, 1)
 		conn.setopt(pycurl.SSL_VERIFYHOST, 2)
-
-	if opt.has_key("--ssl-insecure"):
+	else:
 		conn.setopt(pycurl.SSL_VERIFYPEER, 0)
 		conn.setopt(pycurl.SSL_VERIFYHOST, 0)
 


### PR DESCRIPTION
SSL encrypted communication, so we set it as
default. As pve generates a self signed certificate we set
insecure ssl as default option. A unencrypted connection is rejected
by the PVE proxy so it isn't needed as an option.
Also a typo (opts instead of options) was corrected.