### PR TITLE
fence_ilo: Default to tls1.0

### DIFF
--- a/fence/agents/ilo/fence_ilo.py
+++ b/fence/agents/ilo/fence_ilo.py
@@ -74,6 +74,7 @@ def main():
 	all_opt["login_timeout"]["default"] = "10"
 	all_opt["retry_on"]["default"] = "3"
 	all_opt["ssl"]["default"] = "1"
+	all_opt["tls1.0"]["default"] = "1"
 
 	options = check_input(device_opt, process_input(device_opt))
 


### PR DESCRIPTION
The latest iLO firwares (2.27 and later) disable SSLv3 by default and
fail at auto-negotiating TLS versions.  Forcing TLSv1.0 results in a
working connection by default.