### PR TITLE
fence_scsi: Reset device prior to all uses of sg_persist

### DIFF
--- a/fence/agents/scsi/fence_scsi.py
+++ b/fence/agents/scsi/fence_scsi.py
@@ -101,6 +101,7 @@ def is_block_device(dev):
 
 # cancel registration
 def preempt_abort(options, host, dev):
+	reset_dev(options,dev)
 	cmd = options["--sg_persist-path"] + " -n -o -A -T 5 -K " + host + " -S " + options["--key"] + " -d " + dev
 	return not bool(run_cmd(options, cmd)["err"])
 
@@ -123,11 +124,13 @@ def register_dev(options, dev):
 
 
 def reserve_dev(options, dev):
+	reset_dev(options,dev)
 	cmd = options["--sg_persist-path"] + " -n -o -R -T 5 -K " + options["--key"] + " -d " + dev
 	return not bool(run_cmd(options, cmd)["err"])
 
 
 def get_reservation_key(options, dev):
+	reset_dev(options,dev)
 	cmd = options["--sg_persist-path"] + " -n -i -r -d " + dev
 	out = run_cmd(options, cmd)
 	if out["err"]:
@@ -137,6 +140,7 @@ def get_reservation_key(options, dev):
 
 
 def get_registration_keys(options, dev):
+	reset_dev(options,dev)
 	keys = []
 	cmd = options["--sg_persist-path"] + " -n -i -k -d " + dev
 	out = run_cmd(options, cmd)


### PR DESCRIPTION
Currently the agent will reset prior to several areas where it runs
sg_persist, to clear out any "Unit Attention" conditions that could
otherwise cause the sg_persist command to report failures.  However
several paths remain that could fail if a "Unit Attention" condition
exist, so we should reset before any use of sg_persist.