### PR TITLE
fence_scsi: Offer hard-reboot option for fence_scsi_check script

### DIFF
--- a/fence/agents/scsi/fence_scsi.py
+++ b/fence/agents/scsi/fence_scsi.py
@@ -345,7 +345,7 @@ def scsi_check_get_verbose():
 	return bool(match)
 
 
-def scsi_check():
+def scsi_check(hardreboot=False):
 	if len(sys.argv) >= 3 and sys.argv[1] == "repair":
 		return int(sys.argv[2])
 	options = {}
@@ -369,6 +369,9 @@ def scsi_check():
 		else:
 			logging.debug("key " + key + " not registered with device " + dev)
 	logging.debug("key " + key + " registered with any devices")
+
+	if hardreboot == True:
+		os.system("reboot -f")
 	return 2
 
 
@@ -387,6 +390,8 @@ def main():
 	#fence_scsi_check
 	if os.path.basename(sys.argv[0]) == "fence_scsi_check":
 		sys.exit(scsi_check())
+	elif os.path.basename(sys.argv[0]) == "fence_scsi_check_hardreboot":
+		sys.exit(scsi_check(True))
 
 	options = check_input(device_opt, process_input(device_opt), other_conditions=True)
 


### PR DESCRIPTION
The existing implementation of fence_scsi_check returns an error if any
device is no longer registered properly, and this error return causes
watchdog to use its custom procedure to reboot the host.  This procedure
is prone to blocking, especially when GFS2 file systems are mounted or
multipath devices are configured to queue indefinitely, so having the
check be able to hard-reboot the host instead of returning a failure
gives a means for avoiding these blockages.