### PR TITLE
Low:The error output when operator failed in the practice of the command.

### DIFF
--- a/fence/agents/docker/fence_docker.py
+++ b/fence/agents/docker/fence_docker.py
@@ -88,6 +88,8 @@ specify: --tlscert, --tlskey and --tlscacert")
 	except pycurl.error:
 		logging.error("Connection failed")
 	except:
+		if result is not None:
+			logging.error(result)
 		logging.error("Cannot parse json")
 	return None
 


### PR DESCRIPTION
When setting of Docker is necessary, a message of Docker is displayed by
on commands.
However, fence_docker does not display it.
This patch displays a result when "Cannot parse json" error happened.

For example, an error(Cannot parse json) happens without setting the next option when operator execute on command.

```
/etc/sysconfig/docker-storage
DOCKER_STORAGE_OPTIONS="--storage-opt dm.no_warn_on_loop_devices=true"
```

[root@centos-master ~]# fence_docker -o on -a localhost -u 4243 -n test2
Cannot parse json
Success: Powered ON

The Docker command outputs the next message, but current fence_docker does not display it.

```
Usage of loopback devices is strongly discouraged for production use. Either use `--storage-opt dm.thinpooldev` or use `--storage-opt dm.no_warn_on_loop_devices=true` to suppress this warning.
```

Best Regards,
Hideo Yamauch.