### PR TITLE
Set mark host down flag if possible

### DIFF
--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -92,15 +92,28 @@ def set_power_status(_, options):
 			override_status = "on"
 		return
 
-	# need to wait for nova to update its internal status or we
-	# cannot call host-evacuate
-	while get_power_status(_, options) != "off":
-		# Loop forever if need be.
-		#
-		# Some callers (such as Pacemaker) will have a timer
-		# running and kill us if necessary
-		logging.debug("Waiting for nova to update it's internal state")
-		time.sleep(1)
+	try:
+		nova.services.force_down(
+			options["--plug"], "nova-compute", force_down=True)
+	except Exception:
+		# Something went wrong when we tried to force the host down.
+		# That could come from either an incompatible API version
+		# eg. UnsupportedVersion or VersionNotFoundForAPIMethod
+		# or because novaclient is old and doesn't include force_down yet
+		# eg. AttributeError
+		# In that case, fallbacking to wait for Nova to catch the right state
+		# TODO(sbauza): Need to implement the call to force_down=False when
+		# the host is back up
+
+		# need to wait for nova to update its internal status or we
+		# cannot call host-evacuate
+		while get_power_status(_, options) != "off":
+			# Loop forever if need be.
+			#
+			# Some callers (such as Pacemaker) will have a timer
+			# running and kill us if necessary
+			logging.debug("Waiting for nova to update it's internal state")
+			time.sleep(1)
 
 	if options["--no-shared-storage"] != "False":
 		on_shared_storage = False


### PR DESCRIPTION
DO NOT MERGE YET: I have a question below, please answer it before we merge that proposal, or it would prevent an host to bring back automatically when the service is up.

Since Nova API version 2.11, there is now a new novaclient tool
that allows to bypass the servicegroup check and not wait for it
to catch the right host liveness. Using it as a first try and if
failing, fallbacking to the existing polling.
