### PR TITLE
fix 'evacute' typo

### DIFF
--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -73,7 +73,7 @@ def _host_evacuate(host, on_shared_storage):
 
 def set_attrd_status(host, status, options):
 	logging.debug("Setting fencing status for %s to %s" % (host, status))
-	run_command(options, "attrd_updater -p -n evacute -Q -N %s -v %s" % (host, status))
+	run_command(options, "attrd_updater -p -n evacuate -Q -N %s -v %s" % (host, status))
 
 def set_power_status(_, options):
 	global override_status


### PR DESCRIPTION
This requires the [corresponding fix in `NovaCompute` and `NovaEvacuate`](https://review.openstack.org/#/c/247048/).