### PR TITLE
fence_ipmilan: add a new method diag for the reboot action

### DIFF
--- a/fence/agents/ipmilan/fence_ipmilan.py
+++ b/fence/agents/ipmilan/fence_ipmilan.py
@@ -27,6 +27,10 @@ def reboot_cycle(_, options):
 	output = run_command(options, create_command(options, "cycle"))
 	return bool(re.search('chassis power control: cycle', str(output).lower()))
 
+def reboot_diag(_, options):
+	output = run_command(options, create_command(options, "diag"))
+	return bool(re.search('chassis power control: diag', str(output).lower()))
+
 def create_command(options, action):
 	cmd = options["--ipmitool-path"]
 
@@ -156,7 +160,12 @@ This agent calls support software ipmitool (http://ipmitool.sf.net/)."
 	if not is_executable(options["--ipmitool-path"]):
 		fail_usage("Ipmitool not found or not accessible")
 
-	result = fence_action(None, options, set_power_status, get_power_status, None, reboot_cycle)
+	if options["--method"].lower() == "diag":
+		reboot_fn = reboot_diag
+	else:
+		reboot_fn = reboot_cycle
+
+	result = fence_action(None, options, set_power_status, get_power_status, None, reboot_fn)
 	sys.exit(result)
 
 if __name__ == "__main__":

--- a/fence/agents/lib/fencing.py.py
+++ b/fence/agents/lib/fencing.py.py
@@ -367,11 +367,11 @@ all_opt = {
 	"method" : {
 		"getopt" : "m:",
 		"longopt" : "method",
-		"help" : "-m, --method=[method]          Method to fence (onoff|cycle) (Default: onoff)",
+		"help" : "-m, --method=[method]          Method to fence (onoff|cycle|diag) (Default: onoff)",
 		"required" : "0",
 		"shortdesc" : "Method to fence",
 		"default" : "onoff",
-		"choices" : ["onoff", "cycle"],
+		"choices" : ["onoff", "cycle", "diag"],
 		"order" : 1},
 	"telnet_path" : {
 		"getopt" : ":",
@@ -752,7 +752,7 @@ def show_docs(options, docs=None):
 		print __main__.REDHAT_COPYRIGHT
 		sys.exit(0)
 
-def fence_action(connection, options, set_power_fn, get_power_fn, get_outlet_list=None, reboot_cycle_fn=None):
+def fence_action(connection, options, set_power_fn, get_power_fn, get_outlet_list=None, reboot_fn=None):
 	result = 0
 
 	try:
@@ -820,9 +820,9 @@ def fence_action(connection, options, set_power_fn, get_power_fn, get_outlet_lis
 				fail(EC_WAITING_OFF)
 		elif options["--action"] == "reboot":
 			power_on = False
-			if options.get("--method", "").lower() == "cycle" and reboot_cycle_fn is not None:
+			if options.get("--method", "").lower() in ["cycle", "diag"] and reboot_fn is not None:
 				for _ in range(1, 1 + int(options["--retry-on"])):
-					if reboot_cycle_fn(connection, options):
+					if reboot_fn(connection, options):
 						power_on = True
 						break
 

--- a/tests/data/metadata/fence_amt.xml
+++ b/tests/data/metadata/fence_amt.xml
@@ -44,6 +44,7 @@
 		<content type="select" default="onoff"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_docker.xml
+++ b/tests/data/metadata/fence_docker.xml
@@ -33,6 +33,7 @@
 		<content type="select" default="onoff"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_idrac.xml
+++ b/tests/data/metadata/fence_idrac.xml
@@ -61,6 +61,7 @@
 		<content type="select" default="onoff"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_ilo3.xml
+++ b/tests/data/metadata/fence_ilo3.xml
@@ -61,6 +61,7 @@
 		<content type="select" default="cycle"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_ilo3_ssh.xml
+++ b/tests/data/metadata/fence_ilo3_ssh.xml
@@ -50,6 +50,7 @@
 		<content type="select" default="onoff"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_ilo4.xml
+++ b/tests/data/metadata/fence_ilo4.xml
@@ -61,6 +61,7 @@
 		<content type="select" default="onoff"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_ilo4_ssh.xml
+++ b/tests/data/metadata/fence_ilo4_ssh.xml
@@ -50,6 +50,7 @@
 		<content type="select" default="onoff"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_ilo_ssh.xml
+++ b/tests/data/metadata/fence_ilo_ssh.xml
@@ -50,6 +50,7 @@
 		<content type="select" default="onoff"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_imm.xml
+++ b/tests/data/metadata/fence_imm.xml
@@ -61,6 +61,7 @@
 		<content type="select" default="onoff"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_ipmilan.xml
+++ b/tests/data/metadata/fence_ipmilan.xml
@@ -61,6 +61,7 @@
 		<content type="select" default="onoff"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_rcd_serial.xml
+++ b/tests/data/metadata/fence_rcd_serial.xml
@@ -13,6 +13,7 @@
 		<content type="select" default="cycle"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_sbd.xml
+++ b/tests/data/metadata/fence_sbd.xml
@@ -18,6 +18,7 @@
 		<content type="select" default="cycle"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_zvmip.xml
+++ b/tests/data/metadata/fence_zvmip.xml
@@ -52,6 +52,7 @@ Where XXXXXXX is the name of the virtual machine used in the authuser field of t
 		<content type="select" default="onoff"  >
 			<option value="onoff" />
 			<option value="cycle" />
+			<option value="diag" />
 		</content>
 		<shortdesc lang="en">Method to fence</shortdesc>
 	</parameter>


### PR DESCRIPTION
In some context, it can be useful to trigger kdump on a host while fencing it.
This patch allows to combine the reboot action with the method 'diag', based
upon the existant method 'cycle'.