### PR TITLE
Fix list of servers per host

### DIFF
--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -96,7 +96,8 @@ def _host_evacuate(host, on_shared_storage):
 	response = []
 	flavors = _get_evacuable_flavors()
 	images = _get_evacuable_images()
-	servers = nova.servers.list(search_opts={'hypervisor': host})
+	# Get the list of servers belonging to the host
+	servers = nova.servers.list(search_opts={'host': host})
 	# Identify all evacuable servers
 	evacuables = [server for server in servers
 	              if _is_server_evacuable(server, flavors, images)]


### PR DESCRIPTION
The previous query was incorrect, we need to use the 'host' keyname for getting
the list of instances per host as it's specified in
http://developer.openstack.org/api-ref-compute-v2.1.html#listServers