### PR TITLE
fence_compute: Evacuate instances on all tenants

### DIFF
--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -103,7 +103,7 @@ def _get_evacuable_images():
 
 def _host_evacuate(options):
 	result = True
-	servers = nova.servers.list(search_opts={'host': options["--plug"]})
+	servers = nova.servers.list(search_opts={'host': options["--plug"], 'all_tenants': 1})
 	if options["--instance-filtering"] == "False":
 		evacuables = servers
 	else:


### PR DESCRIPTION
We don't want to evacuate instances in just one tenant, so when we list
the instances, we need to look at all tenants, not just the current one.