### PR TITLE
fence_compute: Do not list hypervisors but nova-compute services and deprecate domain option

### DIFF
--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -34,7 +34,7 @@ def get_power_status(_, options):
 
 	if nova:
 		try:
-			services = nova.services.list(host=options["--plug"])
+			services = nova.services.list(host=options["--plug"], binary="nova-compute")
 			for service in services:
 				logging.debug("Status of %s is %s" % (service.binary, service.state))
 				if service.binary == "nova-compute":

--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -202,15 +202,9 @@ def get_plugs_list(_, options):
 	result = {}
 
 	if nova:
-		hypervisors = nova.hypervisors.list()
-		for hypervisor in hypervisors:
-			longhost = hypervisor.hypervisor_hostname
-			if options["--domain"] != "":
-				shorthost = longhost.replace("." + options["--domain"], "")
-				result[longhost] = ("", None)
-				result[shorthost] = ("", None)
-			else:
-				result[longhost] = ("", None)
+		services = nova.services.list(binary="nova-compute")
+		for service in services:
+			result[service.host] = ("", None)
 	return result
 
 

--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -239,9 +239,9 @@ def define_new_opts():
 	all_opt["domain"] = {
 		"getopt" : "d:",
 		"longopt" : "domain",
-		"help" : "-d, --domain=[string]          DNS domain in which hosts live, useful when the cluster uses short names and nova uses FQDN",
+		"help" : "-d, --domain=[string]          Deprecated option; do not do anything anymore",
 		"required" : "0",
-		"shortdesc" : "DNS domain in which hosts live",
+		"shortdesc" : "Deprecated option",
 		"default" : "",
 		"order": 5,
 	}
@@ -299,10 +299,6 @@ def main():
 		from novaclient import client as nova_client
 	except ImportError:
 		fail_usage("nova not found or not accessible")
-
-	# Potentially we should make this a pacemaker feature
-	if options["--action"] != "list" and options["--domain"] != "" and options.has_key("--plug"):
-		options["--plug"] = options["--plug"] + "." + options["--domain"]
 
 	if options["--record-only"] in [ "2", "Disabled", "disabled" ]:
 		sys.exit(0)

--- a/tests/data/metadata/fence_compute.xml
+++ b/tests/data/metadata/fence_compute.xml
@@ -46,7 +46,7 @@
 	<parameter name="domain" unique="0" required="0">
 		<getopt mixed="-d, --domain=[string]" />
 		<content type="string" default=""  />
-		<shortdesc lang="en">DNS domain in which hosts live</shortdesc>
+		<shortdesc lang="en">Deprecated option</shortdesc>
 	</parameter>
 	<parameter name="instance-filtering" unique="0" required="0">
 		<getopt mixed="--instance-filtering" />


### PR DESCRIPTION
There's no reason to list hypervisors, and this bit was actually, as far as I can tell, the only reason to have a domain option.