### PR TITLE
Explicitly use version 3 of the oVirt API

### DIFF
--- a/fence/agents/rhevm/fence_rhevm.py
+++ b/fence/agents/rhevm/fence_rhevm.py
@@ -81,14 +81,24 @@ def send_command(opt, command, method="GET"):
 		url = "https:"
 	else:
 		url = "http:"
+	if opt.has_key("--api-path"):
+		api_path = opt["--api-path"]
+	else:
+		api_path = "/ovirt-engine/api"
 
-	url += "//" + opt["--ip"] + ":" + str(opt["--ipport"]) + "/api/" + command
+	url += "//" + opt["--ip"] + ":" + str(opt["--ipport"]) + api_path + "/" + command
 
 	## send command through pycurl
 	conn = pycurl.Curl()
 	web_buffer = io.BytesIO()
 	conn.setopt(pycurl.URL, url)
-	conn.setopt(pycurl.HTTPHEADER, ["Content-type: application/xml", "Accept: application/xml", "Prefer: persistent-auth", "Filter: true"])
+	conn.setopt(pycurl.HTTPHEADER, [
+		"Version: 3",
+		"Content-type: application/xml",
+		"Accept: application/xml",
+		"Prefer: persistent-auth",
+		"Filter: true",
+	])
 
 	if "cookie" in opt:
 		conn.setopt(pycurl.COOKIE, opt["cookie"])
@@ -136,9 +146,27 @@ def define_new_opts():
 		"required" : "0",
 		"shortdesc" : "Reuse cookies for authentication",
 		"order" : 1}
+	all_opt["api_path"] = {
+		"getopt" : "",
+		"longopt" : "api-path",
+		"help" : "--api-path                     The path part of the API URL",
+		"default" : "/ovirt-engine/api",
+		"required" : "0",
+		"shortdesc" : "The path part of the API URL",
+		"order" : 2}
 
 def main():
-	device_opt = ["ipaddr", "login", "passwd", "ssl", "notls", "web", "port", "use_cookies" ]
+	device_opt = [
+		"ipaddr",
+		"api_path",
+		"login",
+		"passwd",
+		"ssl",
+		"notls",
+		"web",
+		"port",
+		"use_cookies",
+	]
 
 	atexit.register(atexit_handler)
 	define_new_opts()

--- a/tests/data/metadata/fence_rhevm.xml
+++ b/tests/data/metadata/fence_rhevm.xml
@@ -73,6 +73,10 @@
 		<content type="boolean"  />
 		<shortdesc lang="en">Reuse cookies for authentication</shortdesc>
 	</parameter>
+	<parameter name="api_path" unique="0" required="0">
+		<getopt mixed="--api-path" />
+		<shortdesc lang="en">The path part of the API URL</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />


### PR DESCRIPTION
Version on 4 of the oVirt engine will support two versions of the API:
version 3, which will be backwards compatible with older versions of the
engine, and version 4, which won't be compatible. The default used by the
server will be version 4, but clients can explicitly request a version
of the API using the "Version" header or the "/v3" URL prefix. The
header is the preferred mechanism because it is just ignored by older
versions of the server. This patch modifies the oVirt fence agent so
that the path and version of the API are configuratble, and so that
their default values work correctly with version 3 compatibility mode of
the API.

Signed-off-by: Juan Hernandez juan.hernandez@redhat.com
