### PR TITLE
this fix allows to use dedicated user for fencing, not only root@pam

### DIFF
--- a/fence/agents/pve/fence_pve.py
+++ b/fence/agents/pve/fence_pve.py
@@ -105,7 +105,10 @@ def send_cmd(options, cmd, post=None):
 		conn.setopt(pycurl.COOKIE, options["auth"]["ticket"])
 		conn.setopt(pycurl.HTTPHEADER, [options["auth"]["CSRF_token"]])
 	if post is not None:
-		conn.setopt(pycurl.POSTFIELDS, urllib.urlencode(post))
+    	if "skiplock" in post:
+        	conn.setopt(conn.CUSTOMREQUEST, 'POST')
+    	else:
+        	conn.setopt(pycurl.POSTFIELDS, urllib.urlencode(post))
 	conn.setopt(pycurl.WRITEFUNCTION, output_buffer.write)
 	conn.setopt(pycurl.TIMEOUT, int(options["--shell-timeout"]))
 	if "--ssl" in options or "--ssl-secure" in options:


### PR DESCRIPTION
More info to problem [1], this fixes the problem and allows to use dedicated user only with "VM.PowerMgmt" permission.

 https://forum.proxmox.com/threads/right-permissions-to-stop-vm-with-fence_pve.26618/#post-133621