### PR TITLE
fence_compute: Fix domain handling

### DIFF
--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -34,7 +34,7 @@ def get_power_status(_, options):
 
 	if nova:
 		try:
-			services = nova.services.list(host=options["--plug"])
+			services = nova.services.list(host=options["--plug"], binary="nova-compute")
 			for service in services:
 				logging.debug("Status of %s is %s" % (service.binary, service.state))
 				if service.binary == "nova-compute":

--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -254,8 +254,8 @@ def fix_domain(options):
 		options["--domain"] = last_domain
 		return options["--domain"]
 
-	elif len(domains) == 1:
-		logging.error("Overriding supplied domain '%s' does not match the one calculated from: %s"
+	elif len(domains) == 1 and options["--domain"] != last_domain:
+		logging.error("Overriding supplied domain '%s' as it does not match the one calculated from: %s"
 			      % (options["--domain"], service.host))
 		options["--domain"] = last_domain
 		return options["--domain"]

--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -218,23 +218,23 @@ def fix_domain(options):
 	if nova:
 		# Find it in nova
 
-		hypervisors = nova.hypervisors.list()
-		for hypervisor in hypervisors:
-			shorthost = hypervisor.hypervisor_hostname.split('.')[0]
+		services = nova.services.list(binary="nova-compute")
+		for service in services:
+			shorthost = service.host.split('.')[0]
 
-			if shorthost == hypervisor.hypervisor_hostname:
+			if shorthost == service.host:
 				# Nova is not using FQDN 
 				calculated = ""
 			else:
 				# Compute nodes are named as FQDN, strip off the hostname
-				calculated = hypervisor.hypervisor_hostname.replace(shorthost+".", "")
+				calculated = service.host.replace(shorthost+".", "")
 
 			domains[calculated] = shorthost
 
 			if calculated == last_domain:
 				# Avoid complaining for each compute node with the same name
 				# One hopes they don't appear interleaved as A.com B.com A.com B.com
-				logging.debug("Calculated the same domain from: %s" % hypervisor.hypervisor_hostname)
+				logging.debug("Calculated the same domain from: %s" % service.host)
 
 			elif "--domain" in options and options["--domain"] == calculated:
 				# Supplied domain name is valid 
@@ -243,7 +243,7 @@ def fix_domain(options):
 			elif "--domain" in options:
 				# Warn in case nova isn't available at some point
 				logging.warning("Supplied domain '%s' does not match the one calculated from: %s"
-					      % (options["--domain"], hypervisor.hypervisor_hostname))
+					      % (options["--domain"], service.host))
 
 			last_domain = calculated
 
@@ -256,7 +256,7 @@ def fix_domain(options):
 
 	elif len(domains) == 1:
 		logging.error("Overriding supplied domain '%s' does not match the one calculated from: %s"
-			      % (options["--domain"], hypervisor.hypervisor_hostname))
+			      % (options["--domain"], service.host))
 		options["--domain"] = last_domain
 		return options["--domain"]
 
@@ -298,9 +298,9 @@ def get_plugs_list(_, options):
 	result = {}
 
 	if nova:
-		hypervisors = nova.hypervisors.list()
-		for hypervisor in hypervisors:
-			longhost = hypervisor.hypervisor_hostname
+		services = nova.services.list(binary="nova-compute")
+		for service in services:
+			longhost = service.host
 			shorthost = longhost.split('.')[0]
 			result[longhost] = ("", None)
 			result[shorthost] = ("", None)

--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -37,14 +37,13 @@ def get_power_status(_, options):
 			services = nova.services.list(host=options["--plug"], binary="nova-compute")
 			for service in services:
 				logging.debug("Status of %s is %s" % (service.binary, service.state))
-				if service.binary == "nova-compute":
-					if service.state == "up":
-						status = "on"
-					elif service.state == "down":
-						status = "off"
-					else:
-						logging.debug("Unknown status detected from nova: " + service.state)
-					break
+				if service.state == "up":
+					status = "on"
+				elif service.state == "down":
+					status = "off"
+				else:
+					logging.debug("Unknown status detected from nova: " + service.state)
+				break
 		except requests.exception.ConnectionError as err:
 			logging.warning("Nova connection failed: " + str(err))
 	return status

--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -252,20 +252,18 @@ def fix_domain(options):
 
 	elif len(domains) == 1 and "--domain" not in options:
 		options["--domain"] = last_domain
-		return options["--domain"]
 
 	elif len(domains) == 1 and options["--domain"] != last_domain:
 		logging.error("Overriding supplied domain '%s' as it does not match the one calculated from: %s"
 			      % (options["--domain"], service.host))
 		options["--domain"] = last_domain
-		return options["--domain"]
 
 	elif len(domains) > 1:
 		logging.error("The supplied domain '%s' did not match any used inside nova: %s"
 			      % (options["--domain"], repr(domains)))
 		sys.exit(1)
 
-	return None
+	return last_domain
 
 def fix_plug_name(options):
 	if options["--action"] == "list":
@@ -275,14 +273,15 @@ def fix_plug_name(options):
 		return
 
 	calculated = fix_domain(options)
-	short_plug = options["--plug"].split('.')[0]
-	logging.debug("Checking target '%s' against calculated domain '%s'"% (options["--plug"], options["--domain"]))
 
-	if "--domain" not in options:
+	if calculated is None or "--domain" not in options:
 		# Nothing supplied and nova not available... what to do... nothing
 		return
 
-	elif options["--domain"] == "":
+	short_plug = options["--plug"].split('.')[0]
+	logging.debug("Checking target '%s' against calculated domain '%s'"% (options["--plug"], calculated))
+
+	if options["--domain"] == "":
 		# Ensure any domain is stripped off since nova isn't using FQDN
 		options["--plug"] = short_plug
 

--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -229,23 +229,19 @@ def fix_domain(options):
 				# Compute nodes are named as FQDN, strip off the hostname
 				calculated = service.host.replace(shorthost+".", "")
 
-			domains[calculated] = shorthost
-
 			if calculated == last_domain:
 				# Avoid complaining for each compute node with the same name
 				# One hopes they don't appear interleaved as A.com B.com A.com B.com
 				logging.debug("Calculated the same domain from: %s" % service.host)
+				continue
 
-			elif "--domain" in options and options["--domain"] == calculated:
-				# Supplied domain name is valid 
-				return
+			domains[calculated] = service.host
+			last_domain = calculated
 
-			elif "--domain" in options:
+			if "--domain" in options and options["--domain"] != calculated:
 				# Warn in case nova isn't available at some point
 				logging.warning("Supplied domain '%s' does not match the one calculated from: %s"
 					      % (options["--domain"], service.host))
-
-			last_domain = calculated
 
 	if len(domains) == 0 and "--domain" not in options:
 		logging.error("Could not calculate the domain names used by compute nodes in nova")
@@ -255,7 +251,7 @@ def fix_domain(options):
 
 	elif len(domains) == 1 and options["--domain"] != last_domain:
 		logging.error("Overriding supplied domain '%s' as it does not match the one calculated from: %s"
-			      % (options["--domain"], service.host))
+			      % (options["--domain"], domains[last_domain]))
 		options["--domain"] = last_domain
 
 	elif len(domains) > 1:

--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -281,8 +281,8 @@ def fix_plug_name(options):
 		# Ensure any domain is stripped off since nova isn't using FQDN
 		options["--plug"] = short_plug
 
-	elif options["--domain"] in options["--plug"]:
-		# Plug already contains the domain, don't re-add 
+	elif options["--plug"].endswith(options["--domain"]):
+		# Plug already uses the domain, don't re-add
 		return
 
 	else:

--- a/tests/data/metadata/fence_compute.xml
+++ b/tests/data/metadata/fence_compute.xml
@@ -9,7 +9,7 @@
 		<shortdesc lang="en">Fencing action</shortdesc>
 	</parameter>
 	<parameter name="auth-url" unique="0" required="0">
-		<getopt mixed="-k, --auth-url=[tenant]" />
+		<getopt mixed="-k, --auth-url=[url]" />
 		<content type="string" default=""  />
 		<shortdesc lang="en">Keystone Admin Auth URL</shortdesc>
 	</parameter>


### PR DESCRIPTION
https://github.com/ClusterLabs/fence-agents/commit/33e63ce9959199bdfdf8167d2f64a85776d30141 changed a bit how the domain is handled, but it comes with some issues:
- there are a number of bugs in the code
- it continues with the use of hypervisors (which are always FQDN) instead of moving everything to nova service hosts (which might not be FQDN) -- this matters because we actually only interact with nova service hosts (for the record, my first attempt to fix this was https://github.com/ClusterLabs/fence-agents/pull/46)
