### PR TITLE
Fix an issue that make fails when using the --with-agents

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -131,11 +131,22 @@ if test "x$AGENTS_LIST" = x; then
 fi
 
 if test "x$AGENTS_LIST" != xall; then
+	TMP=""
 	for j in $AGENTS_LIST; do
 		if ! test -d fence/agents/$j; then
 			AC_ERROR([Agent $j does not exists])
 		fi
+
+		if test "$j" = "lib" -o "$j" = "nss_wrapper" -o "$j" = "autodetect"; then
+			continue
+		fi
+
+		AGENT=`find $srcdir/fence/agents/$j -name '*.py' -printf '%P'`
+		if test -n "$AGENT"; then
+			TMP="$TMP $j/$AGENT"
+		fi
 	done
+	AGENTS_LIST="$TMP"
 fi
 
 if test "x$AGENTS_LIST" = xall; then


### PR DESCRIPTION
Hi!
Because I build fails to specify the --with-agents, will fix it.

```
# ./autogen.sh && ./configure --with-agents="sbd"
(snip)
# make
make  all-recursive
make[1]: Entering directory `/usr/local/src/fence-agents'
Making all in fence/agents/lib
make[2]: Entering directory `/usr/local/src/fence-agents/fence/agents/lib'
make[2]: Nothing to be done for `all'.
make[2]: Leaving directory `/usr/local/src/fence-agents/fence/agents/lib'
Making all in fence
make[2]: Entering directory `/usr/local/src/fence-agents/fence'
Making all in agents
make[3]: Entering directory `/usr/local/src/fence-agents/fence/agents'
make[3]: *** No rule to make target `sbd.py', needed by `sbd'.  Stop.
make[3]: Leaving directory `/usr/local/src/fence-agents/fence/agents'
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory `/usr/local/src/fence-agents/fence'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/usr/local/src/fence-agents'
make: *** [all] Error 2
```
