### PR TITLE
At fence_vbox:34, add 'options' to argument list of call to log_expect()

### DIFF
--- a/fence/agents/vbox/fence_vbox.py
+++ b/fence/agents/vbox/fence_vbox.py
@@ -31,7 +31,7 @@ _domain_re = re.compile(r'^\"(.*)\" \{(.*)\}$')
 def _invoke(conn, options, *cmd):
     prefix = options["--sudo-path"] + " " if "--use-sudo" in options else ""
     conn.sendline(prefix + "VBoxManage " + " ".join(cmd))
-    conn.log_expect(options["--command-prompt"], int(options["--shell-timeout"]))
+    conn.log_expect(options, options["--command-prompt"], int(options["--shell-timeout"]))
 
 
 def get_outlets_status(conn, options):


### PR DESCRIPTION
Hi folks,

I wrote up a bug report as https://github.com/ClusterLabs/fence-agents/issues/89 and here's the patch for it.
