### PR TITLE
fencing: Add option to disable logging to stderr

### DIFF
--- a/fence/agents/autodetect/fencing.py
+++ b/fence/agents/autodetect/fencing.py
@@ -435,13 +435,20 @@ all_opt = {
 	"on_target": {
 		"getopt" : "",
 		"help" : "",
-		"order" : 1}
+		"order" : 1},
+	"quiet": {
+		"getopt" : "q",
+		"longopt": "quiet",
+		"help" : "-q, --quiet                    Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.",
+		"required" : "0",
+		"order" : 50}
 }
 
 # options which are added automatically if 'key' is encountered ("default" is always added)
 DEPENDENCY_OPT = {
 		"default" : ["help", "debug", "verbose", "version", "action", "agent", \
-			"power_timeout", "shell_timeout", "login_timeout", "power_wait", "retry_on", "delay"],
+			"power_timeout", "shell_timeout", "login_timeout", "power_wait", "retry_on", \
+                        "delay", "quiet"],
 		"passwd" : ["passwd_script"],
 		"sudo" : ["sudo_path"],
 		"secure" : ["identity_file", "ssh_options", "ssh_path"],
@@ -642,8 +649,9 @@ def check_input(device_opt, opt, other_conditions = False):
 
 	## add logging to syslog
 	logging.getLogger().addHandler(SyslogLibHandler())
-	## add logging to stderr
-	logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
+	if not options.has_key("--quiet"):
+		## add logging to stderr
+		logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
 
 	(acceptable_actions, _) = _get_available_actions(device_opt)
 

--- a/fence/agents/lib/fencing.py.py
+++ b/fence/agents/lib/fencing.py.py
@@ -445,13 +445,20 @@ all_opt = {
 	"on_target": {
 		"getopt" : "",
 		"help" : "",
-		"order" : 1}
+		"order" : 1},
+	"quiet": {
+		"getopt" : "q",
+		"longopt": "quiet",
+		"help" : "-q, --quiet                    Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.",
+		"required" : "0",
+		"order" : 50}
 }
 
 # options which are added automatically if 'key' is encountered ("default" is always added)
 DEPENDENCY_OPT = {
 		"default" : ["help", "debug", "verbose", "version", "action", "agent", \
-			"power_timeout", "shell_timeout", "login_timeout", "power_wait", "retry_on", "delay"],
+			"power_timeout", "shell_timeout", "login_timeout", "power_wait", "retry_on", \
+			"delay", "quiet"],
 		"passwd" : ["passwd_script"],
 		"sudo" : ["sudo_path"],
 		"secure" : ["identity_file", "ssh_options", "ssh_path"],
@@ -652,8 +659,9 @@ def check_input(device_opt, opt, other_conditions = False):
 
 	## add logging to syslog
 	logging.getLogger().addHandler(SyslogLibHandler())
-	## add logging to stderr
-	logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
+	if "--quiet" not in options:
+		## add logging to stderr
+		logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
 
 	(acceptable_actions, _) = _get_available_actions(device_opt)
 

--- a/tests/data/metadata/fence_alom.xml
+++ b/tests/data/metadata/fence_alom.xml
@@ -68,6 +68,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_amt.xml
+++ b/tests/data/metadata/fence_amt.xml
@@ -62,6 +62,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">IP address or hostname of fencing device (together with --port-as-ip)</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_amt_ws.xml
+++ b/tests/data/metadata/fence_amt_ws.xml
@@ -62,6 +62,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">IP address or hostname of fencing device (together with --port-as-ip)</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_apc.xml
+++ b/tests/data/metadata/fence_apc.xml
@@ -73,6 +73,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">Physical switch number on device</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_apc_snmp.xml
+++ b/tests/data/metadata/fence_apc_snmp.xml
@@ -98,6 +98,11 @@
 		</content>
 		<shortdesc lang="en">Specifies SNMP version to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_azure_arm.xml
+++ b/tests/data/metadata/fence_azure_arm.xml
@@ -43,6 +43,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">Id of the Azure subscription.</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_bladecenter.xml
+++ b/tests/data/metadata/fence_bladecenter.xml
@@ -68,6 +68,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_brocade.xml
+++ b/tests/data/metadata/fence_brocade.xml
@@ -68,6 +68,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_cisco_mds.xml
+++ b/tests/data/metadata/fence_cisco_mds.xml
@@ -97,6 +97,11 @@
 		</content>
 		<shortdesc lang="en">Specifies SNMP version to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_cisco_ucs.xml
+++ b/tests/data/metadata/fence_cisco_ucs.xml
@@ -73,6 +73,11 @@
 		<content type="string" default=""  />
 		<shortdesc lang="en">Additional path needed to access suborganization</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_compute.xml
+++ b/tests/data/metadata/fence_compute.xml
@@ -73,6 +73,11 @@
 		<content type="string" default="False"  />
 		<shortdesc lang="en">Only record the target as needing evacuation</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_docker.xml
+++ b/tests/data/metadata/fence_docker.xml
@@ -76,6 +76,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">Path to client key (PEM format) for TLS authentication.  Required if --ssl option is used.</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_drac.xml
+++ b/tests/data/metadata/fence_drac.xml
@@ -53,6 +53,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">IP address or hostname of fencing device (together with --port-as-ip)</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_drac5.xml
+++ b/tests/data/metadata/fence_drac5.xml
@@ -77,6 +77,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_dummy.xml
+++ b/tests/data/metadata/fence_dummy.xml
@@ -23,6 +23,11 @@
 		<content type="string" default="file"  />
 		<shortdesc lang="en">Type of the dummy fence agent</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_eaton_snmp.xml
+++ b/tests/data/metadata/fence_eaton_snmp.xml
@@ -97,6 +97,11 @@
 		</content>
 		<shortdesc lang="en">Specifies SNMP version to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_emerson.xml
+++ b/tests/data/metadata/fence_emerson.xml
@@ -97,6 +97,11 @@
 		</content>
 		<shortdesc lang="en">Specifies SNMP version to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_eps.xml
+++ b/tests/data/metadata/fence_eps.xml
@@ -55,6 +55,11 @@ Agent basically works by connecting to hidden page and pass appropriate argument
 		<content type="string"  />
 		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_hds_cb.xml
+++ b/tests/data/metadata/fence_hds_cb.xml
@@ -68,6 +68,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_hpblade.xml
+++ b/tests/data/metadata/fence_hpblade.xml
@@ -68,6 +68,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ibmblade.xml
+++ b/tests/data/metadata/fence_ibmblade.xml
@@ -97,6 +97,11 @@
 		</content>
 		<shortdesc lang="en">Specifies SNMP version to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_idrac.xml
+++ b/tests/data/metadata/fence_idrac.xml
@@ -89,6 +89,11 @@
 		</content>
 		<shortdesc lang="en">Privilege level on IPMI device</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ifmib.xml
+++ b/tests/data/metadata/fence_ifmib.xml
@@ -99,6 +99,11 @@ It was written with managed ethernet switches in mind, in order to fence iSCSI S
 		</content>
 		<shortdesc lang="en">Specifies SNMP version to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ilo.xml
+++ b/tests/data/metadata/fence_ilo.xml
@@ -79,6 +79,11 @@
 		<content type="boolean"  />
 		<shortdesc lang="en">Disable TLS negotiation and force TLS1.0. This should only be used for devices that do not support TLS1.1 and up.</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ilo2.xml
+++ b/tests/data/metadata/fence_ilo2.xml
@@ -79,6 +79,11 @@
 		<content type="boolean"  />
 		<shortdesc lang="en">Disable TLS negotiation and force TLS1.0. This should only be used for devices that do not support TLS1.1 and up.</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ilo3.xml
+++ b/tests/data/metadata/fence_ilo3.xml
@@ -89,6 +89,11 @@
 		</content>
 		<shortdesc lang="en">Privilege level on IPMI device</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ilo3_ssh.xml
+++ b/tests/data/metadata/fence_ilo3_ssh.xml
@@ -78,6 +78,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ilo4.xml
+++ b/tests/data/metadata/fence_ilo4.xml
@@ -89,6 +89,11 @@
 		</content>
 		<shortdesc lang="en">Privilege level on IPMI device</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ilo4_ssh.xml
+++ b/tests/data/metadata/fence_ilo4_ssh.xml
@@ -78,6 +78,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ilo_moonshot.xml
+++ b/tests/data/metadata/fence_ilo_moonshot.xml
@@ -68,6 +68,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ilo_mp.xml
+++ b/tests/data/metadata/fence_ilo_mp.xml
@@ -68,6 +68,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ilo_ssh.xml
+++ b/tests/data/metadata/fence_ilo_ssh.xml
@@ -78,6 +78,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_imm.xml
+++ b/tests/data/metadata/fence_imm.xml
@@ -89,6 +89,11 @@
 		</content>
 		<shortdesc lang="en">Privilege level on IPMI device</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_intelmodular.xml
+++ b/tests/data/metadata/fence_intelmodular.xml
@@ -99,6 +99,11 @@ Note: Since firmware update version 2.7, SNMP v2 write support is removed, and r
 		</content>
 		<shortdesc lang="en">Specifies SNMP version to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ipdu.xml
+++ b/tests/data/metadata/fence_ipdu.xml
@@ -97,6 +97,11 @@
 		</content>
 		<shortdesc lang="en">Specifies SNMP version to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ipmilan.xml
+++ b/tests/data/metadata/fence_ipmilan.xml
@@ -89,6 +89,11 @@
 		</content>
 		<shortdesc lang="en">Privilege level on IPMI device</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ironic.xml
+++ b/tests/data/metadata/fence_ironic.xml
@@ -38,6 +38,11 @@
 		<content type="string" default="admin"  />
 		<shortdesc lang="en">Keystone Admin Tenant</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_kdump.xml
+++ b/tests/data/metadata/fence_kdump.xml
@@ -28,6 +28,11 @@
 		<content type="string" default="60" />
 		<shortdesc lang="en">Timeout in seconds</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean" />

--- a/tests/data/metadata/fence_ldom.xml
+++ b/tests/data/metadata/fence_ldom.xml
@@ -70,6 +70,11 @@ Very useful parameter is -c (or cmd_prompt in stdin mode). This must be set to s
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_lpar.xml
+++ b/tests/data/metadata/fence_lpar.xml
@@ -82,6 +82,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_mpath.xml
+++ b/tests/data/metadata/fence_mpath.xml
@@ -19,6 +19,11 @@ The fence_mpath agent works by having a unique key for each node that has to be 
 		<content type="string"  />
 		<shortdesc lang="en">Key to use for the current operation. This key should be unique to a node and have to be written in /etc/multipath.conf. For the "on" action, the key specifies the key use to register the local node. For the "off" action, this key specifies the key to be removed from the device(s).</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_netio.xml
+++ b/tests/data/metadata/fence_netio.xml
@@ -48,6 +48,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ovh.xml
+++ b/tests/data/metadata/fence_ovh.xml
@@ -33,6 +33,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_powerman.xml
+++ b/tests/data/metadata/fence_powerman.xml
@@ -33,6 +33,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">IP address or hostname of fencing device (together with --port-as-ip)</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_pve.xml
+++ b/tests/data/metadata/fence_pve.xml
@@ -53,6 +53,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">Node on which machine is located. (Optional, will be automatically determined)</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_raritan.xml
+++ b/tests/data/metadata/fence_raritan.xml
@@ -48,6 +48,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_rcd_serial.xml
+++ b/tests/data/metadata/fence_rcd_serial.xml
@@ -21,6 +21,11 @@
 		<content type="string" default="/dev/ttyS0"  />
 		<shortdesc lang="en">Port of the serial device</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_rhevm.xml
+++ b/tests/data/metadata/fence_rhevm.xml
@@ -73,6 +73,11 @@
 		<content type="boolean"  />
 		<shortdesc lang="en">Reuse cookies for authentication</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_rsa.xml
+++ b/tests/data/metadata/fence_rsa.xml
@@ -68,6 +68,11 @@
 		<content type="string" default="-F /dev/null"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_rsb.xml
+++ b/tests/data/metadata/fence_rsb.xml
@@ -68,6 +68,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_sanbox2.xml
+++ b/tests/data/metadata/fence_sanbox2.xml
@@ -53,6 +53,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_sbd.xml
+++ b/tests/data/metadata/fence_sbd.xml
@@ -26,6 +26,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_scsi.xml
+++ b/tests/data/metadata/fence_scsi.xml
@@ -34,6 +34,11 @@ The fence_scsi agent works by having each node in the cluster register a unique 
 		<content type="string"  />
 		<shortdesc lang="en">Log output (stdout and stderr) to file</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_tripplite_snmp.xml
+++ b/tests/data/metadata/fence_tripplite_snmp.xml
@@ -98,6 +98,11 @@
 		</content>
 		<shortdesc lang="en">Specifies SNMP version to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_vbox.xml
+++ b/tests/data/metadata/fence_vbox.xml
@@ -70,6 +70,11 @@ By default, vbox needs to log in as a user that is a member of the vboxusers gro
 		<content type="string" default="-t &apos;/bin/bash -c &quot;PS1=\\[EXPECT\\]#\  /bin/bash --noprofile --norc&quot;&apos;"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_virsh.xml
+++ b/tests/data/metadata/fence_virsh.xml
@@ -70,6 +70,11 @@ By default, virsh needs root account to do properly work. So you must allow ssh 
 		<content type="string" default="-t &apos;/bin/bash -c &quot;PS1=\\[EXPECT\\]#\  /bin/bash --noprofile --norc&quot;&apos;"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_vmware.xml
+++ b/tests/data/metadata/fence_vmware.xml
@@ -86,6 +86,11 @@ After you have successfully installed VI Perl Toolkit or VIX API, you should be 
 		<content type="string"  />
 		<shortdesc lang="en">VMWare datacenter filter</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_vmware_soap.xml
+++ b/tests/data/metadata/fence_vmware_soap.xml
@@ -70,6 +70,11 @@ Name of virtual machine (-n / port) has to be used in inventory path format (e.g
 		<content type="boolean"  />
 		<shortdesc lang="en">Use SSL connection with verifying certificate</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_wti.xml
+++ b/tests/data/metadata/fence_wti.xml
@@ -68,6 +68,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_xenapi.xml
+++ b/tests/data/metadata/fence_xenapi.xml
@@ -33,6 +33,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">URL to connect to XenServer on</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_zvmip.xml
+++ b/tests/data/metadata/fence_zvmip.xml
@@ -70,6 +70,11 @@ Where XXXXXXX is the name of the virtual machine used in the authuser field of t
 		<content type="string"  />
 		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
 	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />


### PR DESCRIPTION
When using systemd and logging to stderr the journal captures both log messages and stderr together
causing duplicate messages.

Dec 01 16:38:48 d25-22-left fence_ipmilan[25856]: Executing: /usr/bin/ipmitool -I lan -H 172.20.71.75 -U admin -P [set] -p 623 -L ADMINISTRATOR chassis power status
Dec 01 16:38:48 d25-22-left fence_ipmilan[25856]: 0 Chassis Power is on
Dec 01 16:38:49 d25-22-left stonith-ng[23051]:  warning: fence_ipmilan[25856] stderr: [ Executing: /usr/bin/ipmitool -I lan -H 172.20.71.75 -U admin -P [set] -p 623 -L ADMINISTRATOR chassis power status ]
Dec 01 16:38:49 d25-22-left stonith-ng[23051]:  warning: fence_ipmilan[25856] stderr: [  ]
Dec 01 16:38:49 d25-22-left stonith-ng[23051]:  warning: fence_ipmilan[25856] stderr: [ 0 Chassis Power is on ]
Dec 01 16:38:49 d25-22-left stonith-ng[23051]:  warning: fence_ipmilan[25856] stderr: [   ]
Dec 01 16:38:49 d25-22-left stonith-ng[23051]:  warning: fence_ipmilan[25856] stderr: [  ]

Adding this option allows the user to disable the extra messages being logged to stderr.