### PR TITLE
pycurl agents: fix StringIO issues

### DIFF
--- a/fence/agents/cisco_ucs/fence_cisco_ucs.py
+++ b/fence/agents/cisco_ucs/fence_cisco_ucs.py
@@ -114,7 +114,7 @@ def send_command(opt, command, timeout):
 
 	## send command through pycurl
 	conn = pycurl.Curl()
-	web_buffer = io.StringIO()
+	web_buffer = io.BytesIO()
 	conn.setopt(pycurl.URL, url)
 	conn.setopt(pycurl.HTTPHEADER, ["Content-type: text/xml"])
 	conn.setopt(pycurl.POSTFIELDS, command)
@@ -128,7 +128,7 @@ def send_command(opt, command, timeout):
 		conn.setopt(pycurl.SSL_VERIFYPEER, 0)
 		conn.setopt(pycurl.SSL_VERIFYHOST, 0)
 	conn.perform()
-	result = web_buffer.getvalue()
+	result = web_buffer.getvalue().decode()
 
 	logging.debug("%s\n", command)
 	logging.debug("%s\n", result)

--- a/fence/agents/docker/fence_docker.py
+++ b/fence/agents/docker/fence_docker.py
@@ -51,7 +51,7 @@ def get_list(conn, options):
 def send_cmd(options, cmd, post = False):
 	url = "http%s://%s:%s/v%s/%s" % ("s" if "--ssl" in options else "", options["--ip"], options["--ipport"], options["--api-version"], cmd)
 	conn = pycurl.Curl()
-	output_buffer = io.StringIO()
+	output_buffer = io.BytesIO()
 	if logging.getLogger().getEffectiveLevel() < logging.WARNING:
 		conn.setopt(pycurl.VERBOSE, True)
 	conn.setopt(pycurl.HTTPGET, 1)
@@ -77,7 +77,7 @@ specify: --tlscert, --tlskey and --tlscacert")
 
 	try:
 		conn.perform()
-		result = output_buffer.getvalue()
+		result = output_buffer.getvalue().decode()
 		return_code = conn.getinfo(pycurl.RESPONSE_CODE)
 
 		logging.debug("RESULT [" + str(return_code) + \

--- a/fence/agents/pve/fence_pve.py
+++ b/fence/agents/pve/fence_pve.py
@@ -96,7 +96,7 @@ def get_ticket(options):
 def send_cmd(options, cmd, post=None):
 	url = options["url"] + cmd
 	conn = pycurl.Curl()
-	output_buffer = io.StringIO()
+	output_buffer = io.BytesIO()
 	if logging.getLogger().getEffectiveLevel() < logging.WARNING:
 		conn.setopt(pycurl.VERBOSE, True)
 	conn.setopt(pycurl.HTTPGET, 1)
@@ -122,7 +122,7 @@ def send_cmd(options, cmd, post=None):
 
 	try:
 		conn.perform()
-		result = output_buffer.getvalue()
+		result = output_buffer.getvalue().decode()
 
 		logging.debug("RESULT [" + str(conn.getinfo(pycurl.RESPONSE_CODE)) + \
 			"]: " + result)

--- a/fence/agents/rhevm/fence_rhevm.py
+++ b/fence/agents/rhevm/fence_rhevm.py
@@ -86,7 +86,7 @@ def send_command(opt, command, method="GET"):
 
 	## send command through pycurl
 	conn = pycurl.Curl()
-	web_buffer = io.StringIO()
+	web_buffer = io.BytesIO()
 	conn.setopt(pycurl.URL, url)
 	conn.setopt(pycurl.HTTPHEADER, ["Content-type: application/xml", "Accept: application/xml", "Prefer: persistent-auth", "Filter: true"])
 
@@ -121,7 +121,7 @@ def send_command(opt, command, method="GET"):
 
 		opt["cookie"] = cookie
 
-	result = web_buffer.getvalue()
+	result = web_buffer.getvalue().decode()
 
 	logging.debug("%s\n", command)
 	logging.debug("%s\n", result)


### PR DESCRIPTION
Introduced in Python 3 compatibility PR.

.decode() is necessary to be compatible with Python 3.