### PR TITLE
fence_ipmilan: add target support

### DIFF
--- a/fence/agents/ipmilan/fence_ipmilan.py
+++ b/fence/agents/ipmilan/fence_ipmilan.py
@@ -51,13 +51,20 @@ def create_command(options, action):
 
 	Cmd.append(options["--ipmitool-path"])
 
-	# --lanplus / -L
-	if "--lanplus" in options and options["--lanplus"] in ["", "1"]:
-		Cmd.append(" -I lanplus")
+	if "--ip" in options:
+		# --lanplus / -L
+		if "--lanplus" in options and options["--lanplus"] in ["", "1"]:
+			Cmd.append(" -I lanplus")
+		else:
+			Cmd.append(" -I lan")
+		# --ip / -a
+		Cmd.append(" -H " + options["--ip"])
+
+		# --port / -n
+		if "--ipport" in options:
+			Cmd.append(" -p " + options["--ipport"])
 	else:
-		Cmd.append(" -I lan")
-	# --ip / -a
-	Cmd.append(" -H " + options["--ip"])
+		Cmd.append(" -t " + options["--target"])
 
 	# --username / -l
 	if "--username" in options and len(options["--username"]) != 0:
@@ -76,10 +83,6 @@ def create_command(options, action):
 	# --cipher / -C
 	if "--cipher" in options:
 		Cmd.append(" -C " + options["--cipher"])
-
-	# --port / -n
-	if "--ipport" in options:
-		Cmd.append(" -p " + options["--ipport"])
 
 	if "--privlvl" in options:
 		Cmd.append(" -L " + options["--privlvl"])
@@ -136,12 +139,21 @@ def define_new_opts():
 		"default" : "@IPMITOOL_PATH@",
 		"order": 200
 	}
+	all_opt["target"] = {
+		"getopt" : ":",
+		"longopt" : "target",
+		"help" : "--target=[targetaddress]       Bridge IPMI requests to the remote target address",
+		"required" : "0",
+		"shortdesc" : "Bridge IPMI requests to the remote target address",
+		"order": 1
+	}
 
 def main():
 	atexit.register(atexit_handler)
 
-	device_opt = ["ipaddr", "login", "no_login", "no_password", "passwd", "diag",
-		"lanplus", "auth", "cipher", "privlvl", "sudo", "ipmitool_path", "method"]
+	device_opt = ["ipaddr", "login", "no_login", "no_password", "passwd",
+		"diag", "lanplus", "auth", "cipher", "privlvl", "sudo",
+		"ipmitool_path", "method", "target"]
 	define_new_opts()
 
 	all_opt["power_wait"]["default"] = 2

--- a/fence/agents/lib/fencing.py.py
+++ b/fence/agents/lib/fencing.py.py
@@ -1222,7 +1222,7 @@ def _validate_input(options, stop = True):
 		valid_input = False
 		fail_usage("Failed: You have to set login name", stop)
 
-	if device_opt.count("ipaddr") and "--ip" not in options and "--managed" not in options:
+	if device_opt.count("ipaddr") and "--ip" not in options and "--managed" not in options and "--target" not in options:
 		valid_input = False
 		fail_usage("Failed: You have to enter fence address", stop)
 

--- a/tests/data/metadata/fence_idrac.xml
+++ b/tests/data/metadata/fence_idrac.xml
@@ -89,6 +89,11 @@
 		</content>
 		<shortdesc lang="en">Privilege level on IPMI device</shortdesc>
 	</parameter>
+	<parameter name="target" unique="0" required="0">
+		<getopt mixed="--target=[targetaddress]" />
+		<content type="string"  />
+		<shortdesc lang="en">Bridge IPMI requests to the remote target address</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ilo3.xml
+++ b/tests/data/metadata/fence_ilo3.xml
@@ -89,6 +89,11 @@
 		</content>
 		<shortdesc lang="en">Privilege level on IPMI device</shortdesc>
 	</parameter>
+	<parameter name="target" unique="0" required="0">
+		<getopt mixed="--target=[targetaddress]" />
+		<content type="string"  />
+		<shortdesc lang="en">Bridge IPMI requests to the remote target address</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ilo4.xml
+++ b/tests/data/metadata/fence_ilo4.xml
@@ -89,6 +89,11 @@
 		</content>
 		<shortdesc lang="en">Privilege level on IPMI device</shortdesc>
 	</parameter>
+	<parameter name="target" unique="0" required="0">
+		<getopt mixed="--target=[targetaddress]" />
+		<content type="string"  />
+		<shortdesc lang="en">Bridge IPMI requests to the remote target address</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_imm.xml
+++ b/tests/data/metadata/fence_imm.xml
@@ -89,6 +89,11 @@
 		</content>
 		<shortdesc lang="en">Privilege level on IPMI device</shortdesc>
 	</parameter>
+	<parameter name="target" unique="0" required="0">
+		<getopt mixed="--target=[targetaddress]" />
+		<content type="string"  />
+		<shortdesc lang="en">Bridge IPMI requests to the remote target address</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_ipmilan.xml
+++ b/tests/data/metadata/fence_ipmilan.xml
@@ -89,6 +89,11 @@
 		</content>
 		<shortdesc lang="en">Privilege level on IPMI device</shortdesc>
 	</parameter>
+	<parameter name="target" unique="0" required="0">
+		<getopt mixed="--target=[targetaddress]" />
+		<content type="string"  />
+		<shortdesc lang="en">Bridge IPMI requests to the remote target address</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />


### PR DESCRIPTION
Adds --target option to support ipmitool's -t option.