### PR TITLE
Convert URLs passed to pycurl to ASCII

### DIFF
--- a/fence/agents/cisco_ucs/fence_cisco_ucs.py
+++ b/fence/agents/cisco_ucs/fence_cisco_ucs.py
@@ -115,7 +115,7 @@ def send_command(opt, command, timeout):
 	## send command through pycurl
 	conn = pycurl.Curl()
 	web_buffer = io.BytesIO()
-	conn.setopt(pycurl.URL, url)
+	conn.setopt(pycurl.URL, url.encode("ascii"))
 	conn.setopt(pycurl.HTTPHEADER, ["Content-type: text/xml"])
 	conn.setopt(pycurl.POSTFIELDS, command)
 	conn.setopt(pycurl.WRITEFUNCTION, web_buffer.write)

--- a/fence/agents/docker/fence_docker.py
+++ b/fence/agents/docker/fence_docker.py
@@ -55,7 +55,7 @@ def send_cmd(options, cmd, post = False):
 	if logging.getLogger().getEffectiveLevel() < logging.WARNING:
 		conn.setopt(pycurl.VERBOSE, True)
 	conn.setopt(pycurl.HTTPGET, 1)
-	conn.setopt(pycurl.URL, str(url))
+	conn.setopt(pycurl.URL, url.encode("ascii"))
 	if post:
 		conn.setopt(pycurl.POST, 1)
 		conn.setopt(pycurl.POSTFIELDSIZE, 0)

--- a/fence/agents/pve/fence_pve.py
+++ b/fence/agents/pve/fence_pve.py
@@ -100,7 +100,7 @@ def send_cmd(options, cmd, post=None):
 	if logging.getLogger().getEffectiveLevel() < logging.WARNING:
 		conn.setopt(pycurl.VERBOSE, True)
 	conn.setopt(pycurl.HTTPGET, 1)
-	conn.setopt(pycurl.URL, str(url))
+	conn.setopt(pycurl.URL, url.encode("ascii"))
 	if "auth" in options and options["auth"] is not None:
 		conn.setopt(pycurl.COOKIE, options["auth"]["ticket"])
 		conn.setopt(pycurl.HTTPHEADER, [options["auth"]["CSRF_token"]])

--- a/fence/agents/rhevm/fence_rhevm.py
+++ b/fence/agents/rhevm/fence_rhevm.py
@@ -91,7 +91,7 @@ def send_command(opt, command, method="GET"):
 	## send command through pycurl
 	conn = pycurl.Curl()
 	web_buffer = io.BytesIO()
-	conn.setopt(pycurl.URL, url)
+	conn.setopt(pycurl.URL, url.encode("ascii"))
 	conn.setopt(pycurl.HTTPHEADER, [
 		"Version: 3",
 		"Content-type: application/xml",


### PR DESCRIPTION
The 'fence_rhevm' agent uses pycurl to interact with the oVirt API, and
it builds the URLs using string concatenation. For example, to build the
URL used to start a virtual machine it does the following:

  url = "vms/" + options["id"] + "/" + action

This 'id' is extracted from the XML returned by the server, which may be
a plain 'str' or an 'unicode' object, depending on the version of pycurl
used. If it is an unicode object then resulting string will also be an
unicode object. When this unicode object is passed to pycurl it fails,
with the following traceback:

  Traceback (most recent call last):
    ...
    File "/usr/sbin/fence_rhevm", line 106, in send_command
      conn.setopt(pycurl.URL, url)
  TypeError: invalid arguments to setopt

The same happens with other agents. To avoid that this patch changes all
those agents so that they always encode the URL using ASCII before
passing it to pycurl.

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>