### PR TITLE
Make pywsman dependency optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,7 +163,6 @@ AC_PYTHON_MODULE(suds, 1)
 AC_PYTHON_MODULE(pexpect, 1)
 AC_PYTHON_MODULE(pycurl, 1)
 AC_PYTHON_MODULE(requests, 1)
-AC_PYTHON_MODULE(pywsman, 1)
 
 ## path to 3rd-party binaries
 AC_PATH_PROG([IPMITOOL_PATH], [ipmitool], [/usr/bin/ipmitool])

--- a/fence/agents/amt_ws/fence_amt_ws.py
+++ b/fence/agents/amt_ws/fence_amt_ws.py
@@ -24,7 +24,6 @@ sys.path.append("@FENCEAGENTSLIBDIR@")
 from fencing import *
 from fencing import run_delay, fail_usage, fail, EC_STATUS
 
-import pywsman
 from xml.etree import ElementTree
 
 
@@ -63,6 +62,8 @@ def xml_find(doc, namespace, item):
     return tree.find(query)
 
 def _generate_power_action_input(action):
+    import pywsman
+
     method_input = "RequestPowerStateChange_INPUT"
     address = 'http://schemas.xmlsoap.org/ws/2004/08/addressing'
     anonymous = ('http://schemas.xmlsoap.org/ws/2004/08/addressing/'
@@ -87,6 +88,8 @@ def _generate_power_action_input(action):
     return doc
 
 def get_power_status(_, options):
+    import pywsman
+
     client = pywsman.Client(options["--ip"], int(options["--ipport"]), \
                             '/wsman', 'http', 'admin', options["--password"])
     namespace = CIM_AssociatedPowerManagementService
@@ -114,6 +117,8 @@ def get_power_status(_, options):
         fail(EC_STATUS)
 
 def set_power_status(_, options):
+    import pywsman
+
     client = pywsman.Client(options["--ip"], int(options["--ipport"]), \
                             '/wsman', 'http', 'admin', options["--password"])
 
@@ -142,6 +147,8 @@ def set_power_status(_, options):
         fail(EC_STATUS)
 
 def set_boot_order(_, client, options):
+    import pywsman
+
     method_input = "ChangeBootOrder_INPUT"
     address = 'http://schemas.xmlsoap.org/ws/2004/08/addressing'
     anonymous = ('http://schemas.xmlsoap.org/ws/2004/08/addressing/'


### PR DESCRIPTION
If the pywsman python library is only imported when it is actually used,
it becomes possible to generate the man pages for the fence_amt_ws agent
even if it is not installed. That then means that there is no need to
require pywsman for the whole fence-agents package to be installable.

In our (SLE) case, pywsman is only available in the SDK module, so we
can't have a hard require on it in order to build or install the
fence-agents package for HA.