### PR TITLE
Allow to override build date

### DIFF
--- a/scripts/fenceparse
+++ b/scripts/fenceparse
@@ -32,7 +32,7 @@ esac
 
 awk "{print}(\$1 ~ /#BEGIN_VERSION_GENERATION/){exit 0}" $realinfile
 echo ${start}RELEASE_VERSION=\"${release}\"${end}
-echo ${start}BUILD_DATE=\"\(built $(date)\)\"${end}
+echo ${start}BUILD_DATE=\"\(built $(date -u -d@${SOURCE_DATE_EPOCH:-$(date +%s)})\)\"${end}
 if awk -v p=0 "(\$1 ~ /#BEGIN_VERSION_GENERATION/){p = 1} (\$1 ~ /#END_VERSION_GENERATION/){p = 0} {if(p==1)print}" $realinfile | \
 		grep -q REDHAT_COPYRIGHT; then
 	echo ${start}REDHAT_COPYRIGHT=${definedata}${end}


### PR DESCRIPTION
in order to allow for reproducible builds.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.