### PR TITLE
Fix encoding for pexpect with Python 3.6

### DIFF
--- a/fence/agents/lib/fencing.py.py
+++ b/fence/agents/lib/fencing.py.py
@@ -472,9 +472,11 @@ DEPENDENCY_OPT = {
 	}
 
 class fspawn(pexpect.spawn):
-	def __init__(self, options, command):
+	def __init__(self, options, command, **kwargs):
+		if sys.version_info[0] > 2:
+			kwargs.setdefault('encoding', 'utf-8')
 		logging.info("Running command: %s", command)
-		pexpect.spawn.__init__(self, command)
+		pexpect.spawn.__init__(self, command, **kwargs)
 		self.opt = options
 
 	def log_expect(self, pattern, timeout):
@@ -489,6 +491,15 @@ class fspawn(pexpect.spawn):
 	# send EOL according to what was detected in login process (telnet)
 	def send_eol(self, message):
 		return self.send(message + self.opt["eol"])
+
+def frun(command, timeout=30, withexitstatus=False, events=None,
+	 extra_args=None, logfile=None, cwd=None, env=None, **kwargs):
+	if sys.version_info[0] > 2:
+		kwargs.setdefault('encoding', 'utf-8')
+	return pexpect.run(command, timeout=timeout,
+			   withexitstatus=withexitstatus, events=events,
+			   extra_args=extra_args, logfile=logfile, cwd=cwd,
+			   env=env, **kwargs)
 
 def atexit_handler():
 	try:

--- a/fence/agents/lib/fencing_snmp.py.py
+++ b/fence/agents/lib/fencing_snmp.py.py
@@ -5,7 +5,7 @@
 import re, pexpect
 import logging
 from fencing import *
-from fencing import fail, fail_usage, EC_TIMED_OUT, run_delay
+from fencing import fail, fail_usage, EC_TIMED_OUT, run_delay, frun
 
 __all__ = ['FencingSnmp']
 
@@ -87,7 +87,7 @@ class FencingSnmp:
 		try:
 			logging.debug("%s\n", command)
 
-			(res_output, res_code) = pexpect.run(command,
+			(res_output, res_code) = frun(command,
 					int(self.options["--shell-timeout"]) +
 					int(self.options["--login-timeout"]) +
 					additional_timemout, True)

--- a/fence/agents/vmware/fence_vmware.py
+++ b/fence/agents/vmware/fence_vmware.py
@@ -27,7 +27,7 @@ import logging
 import atexit
 sys.path.append("@FENCEAGENTSLIBDIR@")
 from fencing import *
-from fencing import fail, fail_usage, EC_TIMED_OUT, run_delay
+from fencing import fail, fail_usage, EC_TIMED_OUT, run_delay, frun
 
 #BEGIN_VERSION_GENERATION
 RELEASE_VERSION="VMware Agent using VI Perl API and/or VIX vmrun command"
@@ -146,7 +146,7 @@ def vmware_run_command(options, add_login_params, additional_params, additional_
 	try:
 		logging.debug("%s\n", command)
 
-		(res_output, res_code) = pexpect.run(command,
+		(res_output, res_code) = frun(command,
 				int(options["--shell-timeout"]) + int(options["--login-timeout"]) + additional_timeout, True)
 
 		if res_code == None:


### PR DESCRIPTION
Fix encoding issues with pexpect for Python 3.6 (reported in https://github.com/ClusterLabs/fence-agents/issues/132).

Thanks to @feldsam for reporting it.

I've also tested that agents using the subprocess method arent having the same issue.