### PR TITLE
build: release.mk: further alignment with fellow projects (+ fix ifmib README typos)

### DIFF
--- a/fence/agents/ifmib/README
+++ b/fence/agents/ifmib/README
@@ -12,7 +12,7 @@ standard, these identifiers are very widely supported and will not change.
 
 Typical usage:
 --------------
-To use this agen with the switch used on the iSCSI network, you'll require:
+To use this agent with the switch used on the iSCSI network, you'll need:
    1) A managed switch running SNMP.
    2) An SNMP community with write privileges.
    3) Permission to send SNMP through any ACLs or firewalls from the nodes.

--- a/make/release.mk
+++ b/make/release.mk
@@ -5,6 +5,7 @@ gpgsignkey = 0x6CE95CA7  # signing key
 project = fence-agents
 
 deliverables = $(project)-$(version).sha256 \
+               $(project)-$(version).tar.bz2 \
                $(project)-$(version).tar.gz \
                $(project)-$(version).tar.xz
 
@@ -71,22 +72,18 @@ $(project)-$(version).sha256:
 
 .PHONY: sign
 ifeq (,$(gpgsignkey))
-sign: tarballs
+sign: $(deliverables)
 	@echo No GPG signing key defined
 else
 sign: $(project)-$(version).sha256.asc  # "$(deliverables:=.asc)" to sign all
 endif
 
-# NOTE: cannot sign multiple files at once like this
+# NOTE: cannot sign multiple files at once
 $(project)-$(version).%.asc: $(project)-$(version).%
-ifeq (,$(release))
-	@echo Building test release $(version), no sign
-else
-	gpg --default-key "$(gpgsignkey)" \
+	gpg --default-key "$(strip $(gpgsignkey))" \
 		--detach-sign \
 		--armor \
 		$<
-endif
 
 
 .PHONY: publish


### PR DESCRIPTION
* reflect the project is also set to generate bzip2 tarball
  - this change should have been part of d95ee95
* ensure checksum file generated even w/o signing
* allow full-fledged release delivery testing incl. signing
  - these changes should have been part of a8a1d93

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>