### PR TITLE
fence_zvm: fix "uintptr_t" undeclared

### DIFF
--- a/fence/agents/zvm/fence_zvm.c
+++ b/fence/agents/zvm/fence_zvm.c
@@ -25,6 +25,7 @@
 #ifdef __s390__
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>


### PR DESCRIPTION
Include stdint.h now that uintptr_t has been moved there according to C99 standard in libc.