### PR TITLE
fence_ilo_ssh: fix hard reset

### DIFF
--- a/fence/agents/ilo_ssh/fence_ilo_ssh.py
+++ b/fence/agents/ilo_ssh/fence_ilo_ssh.py
@@ -2,6 +2,7 @@
 
 import sys, re
 import atexit
+import logging
 sys.path.append("@FENCEAGENTSLIBDIR@")
 from fencing import *
 
@@ -31,6 +32,10 @@ def set_power_status(conn, options):
 def reboot_cycle(conn, options):
 	conn.send_eol("reset /system1 hard")
 	conn.log_expect(options["--command-prompt"], int(options["--power-timeout"]))
+
+	if get_power_status(conn, options) == "off":
+		logging.error("Timed out waiting to power ON\n")
+
 	return True
 
 def main():

--- a/fence/agents/ilo_ssh/fence_ilo_ssh.py
+++ b/fence/agents/ilo_ssh/fence_ilo_ssh.py
@@ -29,7 +29,7 @@ def set_power_status(conn, options):
 	return
 
 def reboot_cycle(conn, options):
-	conn.send_eol("reset hard /system1")
+	conn.send_eol("reset /system1 hard")
 	conn.log_expect(options["--command-prompt"], int(options["--power-timeout"]))
 	return
 

--- a/fence/agents/ilo_ssh/fence_ilo_ssh.py
+++ b/fence/agents/ilo_ssh/fence_ilo_ssh.py
@@ -31,7 +31,7 @@ def set_power_status(conn, options):
 def reboot_cycle(conn, options):
 	conn.send_eol("reset /system1 hard")
 	conn.log_expect(options["--command-prompt"], int(options["--power-timeout"]))
-	return
+	return True
 
 def main():
 	device_opt = ["ipaddr", "login", "passwd", "secure", "cmd_prompt", "method", "telnet"]


### PR DESCRIPTION
The "hard" keyword needs to be after "/system1":
- http://systemmanager.ru/c02063194.en/116744.htm
- http://myexperienceswithunix.blogspot.in/2016/06/reset-hp-proliant-blade-server-from-ilo.html
- https://community.hpe.com/t5/Remote-Lights-Out-Mgmt-iLO-2-iLO/iLO-feature-to-reboot-the-server/td-p/3619880
- https://community.saas.hpe.com/t5/Remote-Lights-Out-Mgmt-iLO-2-iLO/iLO-feature-to-reboot-the-server/td-p/902189