### PR TITLE
fence_heuristics_ping: add fencing agent for conditional fencing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
     - libxml2-utils
     - libcimcclient0-dev
     - swig
+    - iputils-ping
 
 before_install:
   - pip install suds

--- a/configure.ac
+++ b/configure.ac
@@ -214,6 +214,27 @@ AC_PATH_PROG([SNMPGET_PATH], [snmpget], [/usr/bin/snmpget])
 AC_PATH_PROG([NOVA_PATH], [nova], [/usr/bin/nova])
 AC_PATH_PROG([POWERMAN_PATH], [powerman], [/usr/bin/powerman])
 
+AC_PATH_PROG([PING_CMD], [ping])
+AC_PATH_PROG([PING6_CMD], [ping6])
+AC_PATH_PROG([PING4_CMD], [ping4])
+
+if test "x${ac_cv_path_PING_CMD}" = x; then
+	# assume multicall-ping just not available in build-environment
+	PING_CMD="/bin/ping"
+	PING4_CMD="/bin/ping -4"
+	PING6_CMD="/bin/ping -6"
+elif test "x${ac_cv_path_PING6_CMD}" = x; then
+	# just IPv4
+	PING4_CMD="${ac_cv_path_PING_CMD}"
+elif test -L ${ac_cv_path_PING6_CMD}; then
+	# assume multicall-ping
+	PING4_CMD="${ac_cv_path_PING_CMD} -4"
+else
+	# ping is just IPv4
+	PING4_CMD="${ac_cv_path_PING_CMD}"
+fi
+
+
 ## do subst
 
 AC_SUBST([DEFAULT_CONFIG_DIR])
@@ -250,6 +271,7 @@ AC_SUBST([SG_PERSIST_PATH])
 AC_SUBST([SG_TURS_PATH])
 AC_SUBST([VGS_PATH])
 AC_SUBST([POWERMAN_PATH])
+
 
 ## *FLAGS handling
 

--- a/doc/COPYRIGHT
+++ b/doc/COPYRIGHT
@@ -58,6 +58,7 @@ Joel Becker <joel.becker at oracle.com>
 Jonathan Brassow <jbrassow at redhat.com>
 jparsons <jparsons at redhat.com>
 Ken Preslan <kpreslan at redhat.com>
+Klaus Wenninger <kwenning at redhat.com>
 Lon Hohberger <lhh at redhat.com>
 Marc - A. Dahlhaus <mad at wol.de>
 Marek 'marx' Grac <mgrac at redhat.com>

--- a/fence/agents/heuristics_ping/fence_heuristics_ping.py
+++ b/fence/agents/heuristics_ping/fence_heuristics_ping.py
@@ -18,22 +18,16 @@ from fencing import fail_usage, run_command, fence_action, all_opt
 from fencing import atexit_handler, check_input, process_input, show_docs
 from fencing import run_delay
 
-def get_power_fake(con, options):
-	# Hack to hand over an exit-code
-	return get_power_fake.result
-
 def ping_test(con, options):
 	# Send pings to the targets
 
 	if options["--action"] == "on":
 		# we want unfencing to always succeed
-		get_power_fake.result = "on"
 		return True
 
 	if not "--ping-targets" in options or options["--ping-targets"] == "":
 		# "off" was requested so fake "on" to provoke failure
 		logging.error("ping target required")
-		get_power_fake.result = "on"
 		return False
 
 	timeout = int(options["--ping-timeout"])
@@ -95,10 +89,6 @@ def ping_test(con, options):
 
 	if failcount > maxfail:
 		exitcode = False
-		# "off" was requested so fake "on" to provoke failure
-		get_power_fake.result = "on"
-	else:
-		get_power_fake.result = "off"
 
 	return exitcode
 
@@ -192,10 +182,10 @@ def main():
 	result = fence_action(\
 				None, \
 				options, \
-				ping_test, \
-				get_power_fake, \
 				None, \
-				ping_test)
+				None, \
+				reboot_cycle_fn = ping_test,
+				sync_set_power_fn = ping_test)
 
 	# execute the remaining delay
 	run_delay(options, result=result)

--- a/fence/agents/heuristics_ping/fence_heuristics_ping.py
+++ b/fence/agents/heuristics_ping/fence_heuristics_ping.py
@@ -1,0 +1,205 @@
+#!@PYTHON@ -tt
+
+# The Following Agent Has Been Tested On:
+#
+# RHEL 7.4
+#
+
+import io
+import re
+import subprocess
+import shlex
+import sys, stat
+import logging
+import os
+import atexit
+sys.path.append("@FENCEAGENTSLIBDIR@")
+from fencing import fail_usage, run_command, fence_action, all_opt
+from fencing import atexit_handler, check_input, process_input, show_docs
+from fencing import run_delay
+
+def get_power_fake(con, options):
+	# Hack to hand over an exit-code
+	return get_power_fake.result
+
+def ping_test(con, options):
+	# Send pings to the targets
+
+	if options["--action"] == "on":
+		# we want unfencing to always succeed
+		get_power_fake.result = "on"
+		return True
+
+	if not "--ping-targets" in options or options["--ping-targets"] == "":
+		# "off" was requested so fake "on" to provoke failure
+		logging.error("ping target required")
+		get_power_fake.result = "on"
+		return False
+
+	timeout = int(options["--ping-timeout"])
+	count = int(options["--ping-count"])
+	interval = int(options["--ping-interval"])
+	good_required = int(options["--ping-good-count"])
+	maxfail = int(options["--ping-maxfail"])
+	targets = options["--ping-targets"].split(",")
+	exitcode = True
+	p = {}
+	failcount = 0
+	# search string for parsing the results of the ping-executable
+	packet_count = re.compile(r".*transmitted, ([0-9]*) received.*")
+
+	# start a ping-process per target
+	for target in targets:
+		ping_path = '@PING_CMD@'
+		target_mangled = target
+		if target.startswith('inet6:'):
+			if '@PING6_CMD@' == '':
+				p[target] = None
+				continue
+			ping_path = '@PING6_CMD@'
+			target_mangled = target.lstrip('inet6:')
+		elif target.startswith('inet:'):
+			ping_path = '@PING4_CMD@'
+			target_mangled = target.lstrip('inet:')
+
+		ping_cmd = "%s -n -q -W %d -c %d -i %d %s" % (
+			ping_path, timeout, count, interval, target_mangled)
+		logging.info("Running command: %s", ping_cmd)
+		try:
+			p[target] = subprocess.Popen(shlex.split(ping_cmd),
+				stdout=subprocess.PIPE);
+		except OSError:
+			p[target] = None
+
+	# collect the results of the ping-processes
+	for target in targets:
+		good = 0
+		if p[target] != None:
+			p[target].wait()
+			if p[target].returncode == 0:
+				for line in p[target].stdout:
+					searchres = packet_count.search(line)
+					if searchres:
+						good = int(searchres.group(1))
+						break
+				if good >= good_required:
+					logging.info("ping target %s received %d of %d" \
+						% (target, good, count))
+					continue
+			failcount += 1
+			logging.info("ping target %s received %d of %d and thus failed"
+				% (target, good, count))
+		else:
+			failcount += 1
+			logging.error("ping target %s failed on OS level" % target)
+
+	if failcount > maxfail:
+		exitcode = False
+		# "off" was requested so fake "on" to provoke failure
+		get_power_fake.result = "on"
+	else:
+		get_power_fake.result = "off"
+
+	return exitcode
+
+
+def define_new_opts():
+	all_opt["ping_count"] = {
+		"getopt" : ":",
+		"longopt" : "ping-count",
+		"required" : "0",
+		"help" : "--ping-count=[number]          Number of ping-probes to send",
+		"shortdesc" : "The number of ping-probes that is being sent per target",
+		"default" : "10",
+		"order" : 1
+		}
+
+	all_opt["ping_good_count"] = {
+		"getopt" : ":",
+		"longopt" : "ping-good-count",
+		"required" : "0",
+		"help" : "--ping-good-count=[number]     Number of positive ping-probes required",
+		"shortdesc" : "The number of positive ping-probes required to account a target as available",
+		"default" : "8",
+		"order" : 1
+		}
+
+	all_opt["ping_interval"] = {
+		"getopt" : ":",
+		"longopt" : "ping-interval",
+		"required" : "0",
+		"help" : "--ping-interval=[seconds]      Seconds between ping-probes",
+		"shortdesc" : "The interval in seconds between ping-probes",
+		"default" : "1",
+		"order" : 1
+		}
+
+	all_opt["ping_timeout"] = {
+		"getopt" : ":",
+		"longopt" : "ping-timeout",
+		"required" : "0",
+		"help" : "--ping-timeout=[seconds]       Timeout for individual ping-probes",
+		"shortdesc" : "The timeout in seconds till an individual ping-probe is accounted as lost",
+		"default" : "2",
+		"order" : 1
+		}
+
+	all_opt["ping_maxfail"] = {
+		"getopt" : ":",
+		"longopt" : "ping-maxfail",
+		"required" : "0",
+		"help" : "--ping-maxfail=[number]        Number of failed ping-targets allowed",
+		"shortdesc" : "The number of failed ping-targets to still account as overall success",
+		"default" : "0",
+		"order" : 1
+		}
+
+	all_opt["ping_targets"] = {
+		"getopt" : ":",
+		"longopt" : "ping-targets",
+		"required" : "1",
+		"help" : "--ping-targets=tgt1,[inet6:]tgt2  Comma separated list of ping-targets",
+		"shortdesc" : "A comma separated list of ping-targets (optionally prepended by 'inet:' or 'inet6:') to be probed",
+		"default" : "localhost",
+		"order" : 1
+		}
+
+
+def main():
+	device_opt = ["no_status", "no_password", "ping_count", "ping_good_count",
+		"ping_interval", "ping_timeout", "ping_maxfail", "ping_targets", "method"]
+	define_new_opts()
+	atexit.register(atexit_handler)
+
+	all_opt["method"]["default"] = "cycle"
+	all_opt["method"]["help"] = "-m, --method=[method]          Method to fence (cycle|onoff) (Default: cycle)"
+
+	options = check_input(device_opt, process_input(device_opt))
+
+	docs = {}
+	docs["shortdesc"] = "Fence agent for ping-heuristic based fencing"
+	docs["longdesc"] = "fence_heuristics_ping uses ping-heuristics to control execution of another fencing agent on the same fencing-level."
+	docs["vendorurl"] = ""
+	show_docs(options, docs)
+
+	# move ping-test to the end of the time-window set via --delay
+	# as to give the network time to settle after the incident that has
+	# caused fencing and have the results as current as possible
+	max_pingcheck = (int(options["--ping-count"]) - 1) * \
+		int(options["--ping-interval"]) + int(options["--ping-timeout"])
+	run_delay(options, reserve=max_pingcheck)
+
+	result = fence_action(\
+				None, \
+				options, \
+				ping_test, \
+				get_power_fake, \
+				None, \
+				ping_test)
+
+	# execute the remaining delay
+	run_delay(options, result=result)
+	sys.exit(result)
+
+if __name__ == "__main__":
+	main()

--- a/make/fencebuild.mk
+++ b/make/fencebuild.mk
@@ -28,6 +28,9 @@ define gen_agent_from_py
 		-e 's#@''SNMPGET_PATH@#${SNMPGET_PATH}#g' \
 		-e 's#@''NOVA_PATH@#${NOVA_PATH}#g' \
 		-e 's#@''POWERMAN_PATH@#${POWERMAN_PATH}#g' \
+		-e 's#@''PING_CMD@#${PING_CMD}#g' \
+		-e 's#@''PING6_CMD@#${PING6_CMD}#g' \
+		-e 's#@''PING4_CMD@#${PING4_CMD}#g' \
 	> $@
 
 	if [ 0 -eq `echo "$(@)" | grep fence_ &> /dev/null; echo $$?` ]; then \

--- a/tests/data/metadata/fence_heuristics_ping.xml
+++ b/tests/data/metadata/fence_heuristics_ping.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" ?>
+<resource-agent name="fence_heuristics_ping" shortdesc="Fence agent for ping-heuristic based fencing" >
+<longdesc>fence_heuristics_ping uses ping-heuristics to control execution of another fencing agent on the same fencing-level.</longdesc>
+<vendor-url></vendor-url>
+<parameters>
+	<parameter name="action" unique="0" required="1">
+		<getopt mixed="-o, --action=[action]" />
+		<content type="string" default="reboot"  />
+		<shortdesc lang="en">Fencing action</shortdesc>
+	</parameter>
+	<parameter name="method" unique="0" required="0">
+		<getopt mixed="-m, --method=[method]" />
+		<content type="select" default="cycle"  >
+			<option value="onoff" />
+			<option value="cycle" />
+		</content>
+		<shortdesc lang="en">Method to fence</shortdesc>
+	</parameter>
+	<parameter name="ping_count" unique="0" required="0">
+		<getopt mixed="--ping-count=[number]" />
+		<content type="string" default="10"  />
+		<shortdesc lang="en">The number of ping-probes that is being sent per target</shortdesc>
+	</parameter>
+	<parameter name="ping_good_count" unique="0" required="0">
+		<getopt mixed="--ping-good-count=[number]" />
+		<content type="string" default="8"  />
+		<shortdesc lang="en">The number of positive ping-probes required to account a target as available</shortdesc>
+	</parameter>
+	<parameter name="ping_interval" unique="0" required="0">
+		<getopt mixed="--ping-interval=[seconds]" />
+		<content type="string" default="1"  />
+		<shortdesc lang="en">The interval in seconds between ping-probes</shortdesc>
+	</parameter>
+	<parameter name="ping_maxfail" unique="0" required="0">
+		<getopt mixed="--ping-maxfail=[number]" />
+		<content type="string" default="0"  />
+		<shortdesc lang="en">The number of failed ping-targets to still account as overall success</shortdesc>
+	</parameter>
+	<parameter name="ping_targets" unique="0" required="1">
+		<getopt mixed="--ping-targets=tgt1,[inet6:]tgt2" />
+		<content type="string" default="localhost"  />
+		<shortdesc lang="en">A comma separated list of ping-targets (optionally prepended by 'inet:' or 'inet6:') to be probed</shortdesc>
+	</parameter>
+	<parameter name="ping_timeout" unique="0" required="0">
+		<getopt mixed="--ping-timeout=[seconds]" />
+		<content type="string" default="2"  />
+		<shortdesc lang="en">The timeout in seconds till an individual ping-probe is accounted as lost</shortdesc>
+	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug logging to syslog.</shortdesc>
+	</parameter>
+	<parameter name="verbose" unique="0" required="0">
+		<getopt mixed="-v, --verbose" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Verbose mode</shortdesc>
+	</parameter>
+	<parameter name="debug" unique="0" required="0" deprecated="1">
+		<getopt mixed="-D, --debug-file=[debugfile]" />
+		<content type="string"  />
+		<shortdesc lang="en">Write debug information to given file</shortdesc>
+	</parameter>
+	<parameter name="debug_file" unique="0" required="0" obsoletes="debug">
+		<getopt mixed="-D, --debug-file=[debugfile]" />
+		<content type="string"  />
+		<shortdesc lang="en">Write debug information to given file</shortdesc>
+	</parameter>
+	<parameter name="version" unique="0" required="0">
+		<getopt mixed="-V, --version" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Display version information and exit</shortdesc>
+	</parameter>
+	<parameter name="help" unique="0" required="0">
+		<getopt mixed="-h, --help" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Display help and exit</shortdesc>
+	</parameter>
+	<parameter name="delay" unique="0" required="0">
+		<getopt mixed="--delay=[seconds]" />
+		<content type="second" default="0"  />
+		<shortdesc lang="en">Wait X seconds before fencing is started</shortdesc>
+	</parameter>
+	<parameter name="login_timeout" unique="0" required="0">
+		<getopt mixed="--login-timeout=[seconds]" />
+		<content type="second" default="5"  />
+		<shortdesc lang="en">Wait X seconds for cmd prompt after login</shortdesc>
+	</parameter>
+	<parameter name="power_timeout" unique="0" required="0">
+		<getopt mixed="--power-timeout=[seconds]" />
+		<content type="second" default="20"  />
+		<shortdesc lang="en">Test X seconds for status change after ON/OFF</shortdesc>
+	</parameter>
+	<parameter name="power_wait" unique="0" required="0">
+		<getopt mixed="--power-wait=[seconds]" />
+		<content type="second" default="0"  />
+		<shortdesc lang="en">Wait X seconds after issuing ON/OFF</shortdesc>
+	</parameter>
+	<parameter name="shell_timeout" unique="0" required="0">
+		<getopt mixed="--shell-timeout=[seconds]" />
+		<content type="second" default="3"  />
+		<shortdesc lang="en">Wait X seconds for cmd prompt after issuing command</shortdesc>
+	</parameter>
+	<parameter name="retry_on" unique="0" required="0">
+		<getopt mixed="--retry-on=[attempts]" />
+		<content type="integer" default="1"  />
+		<shortdesc lang="en">Count of attempts to retry power on</shortdesc>
+	</parameter>
+</parameters>
+<actions>
+	<action name="on" automatic="0"/>
+	<action name="off" />
+	<action name="reboot" />
+	<action name="monitor" />
+	<action name="metadata" />
+	<action name="validate-all" />
+</actions>
+</resource-agent>


### PR DESCRIPTION
Not really a fencing agent by itself!
Put on the same fencing level with the actual fencing agent for
your node to make actual fencing depend on the result of (own)
connectivity determinded using ping heuristics.

resolves: rhbz#1476401

Tried to make that look as much as other fencing agents as possible
while making as much use of the fencing-library as possible.
This got a little hacky as the whole thing is quite a bit different from
the other fencing agents.
Changes to the fencing-library are minimal and shouldn't alter the
interface for existing fencing agents.