### PR TITLE
Fix: fence_heuristics_ping: make fence-agent fail without params

### DIFF
--- a/fence/agents/Makefile.am
+++ b/fence/agents/Makefile.am
@@ -63,7 +63,8 @@ port=1\n\
 managed=1\n\
 devices=test\n\
 session_url=http://test\n\
-email=test@test.te
+email=test@test.te\n\
+ping_targets=localhost
 
 manual/fence_ack_manual: manual/fence_ack_manual.in
 	mkdir -p $(@D)

--- a/fence/agents/heuristics_ping/fence_heuristics_ping.py
+++ b/fence/agents/heuristics_ping/fence_heuristics_ping.py
@@ -150,7 +150,7 @@ def define_new_opts():
 		"required" : "1",
 		"help" : "--ping-targets=tgt1,[inet6:]tgt2  Comma separated list of ping-targets",
 		"shortdesc" : "A comma separated list of ping-targets (optionally prepended by 'inet:' or 'inet6:') to be probed",
-		"default" : "localhost",
+		"default" : "",
 		"order" : 1
 		}
 
@@ -168,7 +168,10 @@ def main():
 
 	docs = {}
 	docs["shortdesc"] = "Fence agent for ping-heuristic based fencing"
-	docs["longdesc"] = "fence_heuristics_ping uses ping-heuristics to control execution of another fencing agent on the same fencing-level."
+	docs["longdesc"] = "fence_heuristics_ping uses ping-heuristics to control execution of another fence agent on the same fencing level.\
+\n.P\n\
+This is not a fence agent by itself! \
+Its only purpose is to enable/disable another fence agent that lives on the same fencing level but after fence_heuristics_ping."
 	docs["vendorurl"] = ""
 	show_docs(options, docs)
 

--- a/tests/data/metadata/fence_heuristics_ping.xml
+++ b/tests/data/metadata/fence_heuristics_ping.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" ?>
 <resource-agent name="fence_heuristics_ping" shortdesc="Fence agent for ping-heuristic based fencing" >
-<longdesc>fence_heuristics_ping uses ping-heuristics to control execution of another fencing agent on the same fencing-level.</longdesc>
+<longdesc>fence_heuristics_ping uses ping-heuristics to control execution of another fence agent on the same fencing level.
+.P
+This is not a fence agent by itself! Its only purpose is to enable/disable another fence agent that lives on the same fencing level but after fence_heuristics_ping.</longdesc>
 <vendor-url></vendor-url>
 <parameters>
 	<parameter name="action" unique="0" required="1">
@@ -38,7 +40,7 @@
 	</parameter>
 	<parameter name="ping_targets" unique="0" required="1">
 		<getopt mixed="--ping-targets=tgt1,[inet6:]tgt2" />
-		<content type="string" default="localhost"  />
+		<content type="string" default=""  />
 		<shortdesc lang="en">A comma separated list of ping-targets (optionally prepended by 'inet:' or 'inet6:') to be probed</shortdesc>
 	</parameter>
 	<parameter name="ping_timeout" unique="0" required="0">


### PR DESCRIPTION
Without ping_targets given the agent will fail so unintentional usage as kind of a 'dummy'-fence-agent should happen less easily.