### PR TITLE
Update drac5 to support drac8 ssh fence agent

### DIFF
--- a/fence/agents/drac5/fence_drac5.py
+++ b/fence/agents/drac5/fence_drac5.py
@@ -8,6 +8,7 @@
 ## +-----------------+---------------------------+
 ##  DRAC 5             1.0  (Build 06.05.12)
 ##  DRAC 5             1.21 (Build 07.05.04)
+##  DRAC 8             2.43.43.43
 ##
 ## @note: drac_version was removed
 #####
@@ -104,7 +105,7 @@ def main():
 
 	define_new_opts()
 
-	all_opt["cmd_prompt"]["default"] = [r"\$", r"DRAC\/MC:"]
+	all_opt["cmd_prompt"]["default"] = [r"\$", r"DRAC\/MC:", r"\/admin1->"]
 
 	options = check_input(device_opt, process_input(device_opt))
 

--- a/tests/data/metadata/fence_drac5.xml
+++ b/tests/data/metadata/fence_drac5.xml
@@ -10,12 +10,12 @@
 	</parameter>
 	<parameter name="cmd_prompt" unique="0" required="0" deprecated="1">
 		<getopt mixed="-c, --command-prompt=[prompt]" />
-		<content type="string" default="[&apos;\\$&apos;, &apos;DRAC\\/MC:&apos;]"  />
+		<content type="string" default="[&apos;\\$&apos;, &apos;DRAC\\/MC:&apos;, &apos;\\/admin1-&gt;&apos;]"  />
 		<shortdesc lang="en">Force Python regex for command prompt</shortdesc>
 	</parameter>
 	<parameter name="command_prompt" unique="0" required="0" obsoletes="cmd_prompt">
 		<getopt mixed="-c, --command-prompt=[prompt]" />
-		<content type="string" default="[&apos;\\$&apos;, &apos;DRAC\\/MC:&apos;]"  />
+		<content type="string" default="[&apos;\\$&apos;, &apos;DRAC\\/MC:&apos;, &apos;\\/admin1-&gt;&apos;]"  />
 		<shortdesc lang="en">Force Python regex for command prompt</shortdesc>
 	</parameter>
 	<parameter name="drac_version" unique="0" required="0">


### PR DESCRIPTION
This adds a dell drac ssh fence agent, I tested it with drac8. I looked at the tests in tests/data/metadata/fence_ilo_ssh.xml - they should all apply to drac aswell but essentially testing the common parts once should be enough I'd guess :)