### PR TITLE
Proposed fix to address the regex used to located longopt defined wit…

### DIFF
--- a/fence/agents/lib/check_used_options.py
+++ b/fence/agents/lib/check_used_options.py
@@ -24,7 +24,7 @@ def main():
 	## all_opt defined in fence agent are found
 	agent_file = open(agent)
 	opt_re = re.compile(r"\s*all_opt\[\"([^\"]*)\"\] = {")
-	opt_longopt_re = re.compile(r"\s*\"longopt\" : \"([^\"]*)\"")
+	opt_longopt_re = re.compile(r"\"longopt\"\s*:\s*\"([^\"]*)\"")
 
 	in_opt = False
 	for line in agent_file:


### PR DESCRIPTION
…hin the individual fence agents code.  The previous regex does not account for PEP8 guidelines when defining dictionary key value separator spacing.  The defined stylization is to place the colon directly next to the quotation mark.  This regex parser misses this so the fix is to account for both space and no space for backward compatibility.  This parsing issue causes obscure issues when developing new fence agents using PEP8 indentation guidelines.