### PR TITLE
Log the proper nova_versions variable

### DIFF
--- a/fence/agents/compute/fence_compute.py
+++ b/fence/agents/compute/fence_compute.py
@@ -331,7 +331,7 @@ def create_nova_connection(options):
 		except Exception as e:
 			logging.warning("Nova connection failed. %s: %s" % (e.__class__.__name__, e))
 
-	logging.warning("Couldn't obtain a supported connection to nova, tried: %s\n" % repr(versions))
+	logging.warning("Couldn't obtain a supported connection to nova, tried: %s\n" % repr(nova_versions))
 	return None
 
 def define_new_opts():


### PR DESCRIPTION
With 549fee1c18cfb31881c9126ae46a4bd9b20b4716 ("compute: Add support for
keystone v3 authentication") we renamed the versions variable to
nova_versions. Let's make sure we use that when logging so there are
no python exceptions triggered.