### PR TITLE
heuristics_ping: fix for python3 TypeError

### DIFF
--- a/fence/agents/heuristics_ping/fence_heuristics_ping.py
+++ b/fence/agents/heuristics_ping/fence_heuristics_ping.py
@@ -72,7 +72,7 @@ def ping_test(con, options):
 			p[target].wait()
 			if p[target].returncode == 0:
 				for line in p[target].stdout:
-					searchres = packet_count.search(line)
+					searchres = packet_count.search(line.decode())
 					if searchres:
 						good = int(searchres.group(1))
 						break


### PR DESCRIPTION
Traceback (most recent call last):
  File "heuristics_ping/fence_heuristics_ping", line 198, in <module>
    main()
  File "heuristics_ping/fence_heuristics_ping", line 191, in main
    sync_set_power_fn = ping_test)
  File "lib/fencing.py", line 904, in fence_action
    if reboot_cycle_fn(connection, options):
  File "heuristics_ping/fence_heuristics_ping", line 75, in ping_test
    searchres = packet_count.search(line)
TypeError: cannot use a string pattern on a bytes-like object