### PR TITLE
fence_gce : zone & project parameters are mandatory

### DIFF
--- a/fence/agents/gce/fence_gce.py
+++ b/fence/agents/gce/fence_gce.py
@@ -57,17 +57,17 @@ def define_new_opts():
 	all_opt["zone"] = {
 		"getopt" : ":",
 		"longopt" : "zone",
-		"help" : "--zone=[name]            Zone, e.g. us-central1-b",
+		"help" : "--zone=[name]                  Zone, e.g. us-central1-b",
 		"shortdesc" : "Zone.",
-		"required" : "0",
+		"required" : "1",
 		"order" : 2
 	}
 	all_opt["project"] = {
 		"getopt" : ":",
 		"longopt" : "project",
-		"help" : "--project=[name]            Project",
-		"shortdesc" : "Project.",
-		"required" : "0",
+		"help" : "--project=[name]               Project ID",
+		"shortdesc" : "Project ID.",
+		"required" : "1",
 		"order" : 3
 	}
 

--- a/tests/data/metadata/fence_gce.xml
+++ b/tests/data/metadata/fence_gce.xml
@@ -20,15 +20,15 @@ For instructions see: https://cloud.google.com/compute/docs/tutorials/python-gui
 		<content type="string"  />
 		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
 	</parameter>
-	<parameter name="zone" unique="0" required="0">
+	<parameter name="zone" unique="0" required="1">
 		<getopt mixed="--zone=[name]" />
 		<content type="string"  />
 		<shortdesc lang="en">Zone.</shortdesc>
 	</parameter>
-	<parameter name="project" unique="0" required="0">
+	<parameter name="project" unique="0" required="1">
 		<getopt mixed="--project=[name]" />
 		<content type="string"  />
-		<shortdesc lang="en">Project.</shortdesc>
+		<shortdesc lang="en">Project ID.</shortdesc>
 	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />


### PR DESCRIPTION
Hello

The zone & project parameters are required by the Google API :
```
>>> conn.instances().list().execute()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/dist-packages/googleapiclient/discovery.py", line 716, in method
    raise TypeError('Missing required parameter "%s"' % name)
TypeError: Missing required parameter "project"

>>> conn.instances().list(project="myproject").execute()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/dist-packages/googleapiclient/discovery.py", line 716, in method
    raise TypeError('Missing required parameter "%s"' % name)
TypeError: Missing required parameter "zone"
```