### PR TITLE
Mid: fence_docker: Exclude slashes from the list.

### DIFF
--- a/fence/agents/docker/fence_docker.py
+++ b/fence/agents/docker/fence_docker.py
@@ -38,7 +38,7 @@ def get_list(conn, options):
 	output = send_cmd(options, "containers/json?all=1")
 	containers = {}
 	for container in output:
-		containers[container["Id"]] = (container["Names"][0], {True:"off", False: "on"}[container["Status"][:4].lower() == "exit"])
+		containers[container["Id"]] = ({True:container["Names"][0][1:], False: container["Names"][0]}[container["Names"][0][0:1] == '/'], {True:"off", False: "on"}[container["Status"][:4].lower() == "exit"])
 	return containers
 
 


### PR DESCRIPTION
Hi All,

Pacemaker can not handle slashes in the list when running STONITH.

[root@rh74-test ~]# fence_docker -o list -a 127.0.0.1 -u 4243 --api-version 1.12
18e51ee177a941fe4b8b1b16239cf9d8163c5a697d5c7816aba7fde5ba114fae,/docker-remote
For this reason, a parse error occurs.
(As a result, Pacemaker fails in STONITH using fence_docker.)

Eliminate the leading slash of the container name from the result of the list.

[root@rh74-test ~]# fence_docker -o list -a 127.0.0.1 -u 4243 --api-version 1.12
18e51ee177a941fe4b8b1b16239cf9d8163c5a697d5c7816aba7fde5ba114fae,docker-remote

- In consideration of the future change of docker, I skipped only when the slash is at the beginning.

Best Regards,
Hideo Yamauchi.
