### PR TITLE
use compat.py to provide compatibility for python2/3

### DIFF
--- a/fence/agents/lib/Makefile.am
+++ b/fence/agents/lib/Makefile.am
@@ -1,12 +1,12 @@
 MAINTAINERCLEANFILES	= Makefile.in
 
-TARGET			= fencing.py fencing_snmp.py azure_fence.py
+TARGET			= fencing.py fencing_snmp.py azure_fence.py compat.py
 
 if BUILD_XENAPILIB
 TARGET			+= XenAPI.py
 endif
 
-SRC			= fencing.py.py fencing_snmp.py.py XenAPI.py.py azure_fence.py.py check_used_options.py
+SRC			= fencing.py.py fencing_snmp.py.py XenAPI.py.py azure_fence.py.py check_used_options.py compat.py.py
 
 XSL			= fence2man.xsl fence2rng.xsl fence2wiki.xsl
 

--- a/fence/agents/lib/compat.py.py
+++ b/fence/agents/lib/compat.py.py
@@ -1,0 +1,15 @@
+#!@PYTHON@ -tt
+
+import sys
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    def to_ascii(s):
+        if s is None or isinstance(s, str):
+            return s
+        return str(s, 'utf-8')
+else:
+    def to_ascii(s):
+        if s is None or isinstance(s, str):
+            return s

--- a/fence/agents/lib/fencing.py.py
+++ b/fence/agents/lib/fencing.py.py
@@ -10,6 +10,8 @@ import socket
 import textwrap
 import __main__
 
+from compat import to_ascii
+
 RELEASE_VERSION = "@RELEASE_VERSION@"
 
 __all__ = ['atexit_handler', 'check_input', 'process_input', 'all_opt', 'show_docs',
@@ -1014,7 +1016,7 @@ def run_command(options, command, timeout=None, env=None, log_command=None):
 
 	logging.debug("%s %s %s\n", str(status), str(pipe_stdout), str(pipe_stderr))
 
-	return (status, pipe_stdout, pipe_stderr)
+	return (status, to_ascii(pipe_stdout), to_ascii(pipe_stderr))
 
 def run_delay(options, reserve=0, result=0):
 	## Delay is important for two-node clusters fencing


### PR DESCRIPTION
hi:
In python3 environment, agent like fence_sbd which will call run_command function, will raise error about bytes and string convert

I think it's necessary to  use compatible code to handle this problem, 
we can append more functions to compat.py later

regards,
xin