### PR TITLE
Low: fence_scsi: Remove period from cmd string

### DIFF
--- a/fence/agents/scsi/fence_scsi.py
+++ b/fence/agents/scsi/fence_scsi.py
@@ -189,7 +189,7 @@ def get_cluster_id(options):
 
 
 def get_node_id(options):
-	cmd = options["--corosync-cmap-path"] + " nodelist."
+	cmd = options["--corosync-cmap-path"] + " nodelist"
 
 	match = re.search(r".(\d).ring._addr \(str\) = " + options["--nodename"] + "\n", run_cmd(options, cmd)["out"])
 	return match.group(1) if match else fail_usage("Failed: unable to parse output of corosync-cmapctl or node does not exist")


### PR DESCRIPTION
Changes `corosync-cmapctl nodelist.` to `corosync-cmapctl nodelist`.
Existing version works fine in my testing, so this is a simple typo
cleanup.