### PR TITLE
Add agent for OVH Cloud (REST API)

### DIFF
--- a/agents/ovh_cloud_rest/fence_ovh_cloud_rest.py
+++ b/agents/ovh_cloud_rest/fence_ovh_cloud_rest.py
@@ -1,0 +1,124 @@
+#!@PYTHON@ -tt
+
+import sys
+import time
+import atexit
+sys.path.append("@FENCEAGENTSLIBDIR@")
+from fencing import *
+from fencing import fail_usage, run_command, run_delay
+import ovh
+
+POLL_INTERVAL_SECONDS = 1
+
+def define_new_opts():
+    all_opt["application_key"] = {
+            "getopt" : "k:",
+            "longopt" : "application-key",
+            "help" : "-k, --application-key=[application-key]               OVH Oauth application key",
+            "required" : "1",
+            "shortdesc" : "OVH Oauth application key",
+            "order" : 1}
+    all_opt["application_secret"] = {
+            "getopt" : "s:",
+            "longopt" : "application-secret",
+            "help" : "-s, --application-secret=[application-secret]         OVH Oauth application secret",
+            "required" : "1",
+            "shortdesc" : "OVH Oauth application secret",
+            "order" : 2}
+    all_opt["token"] = {
+            "getopt" : "t:",
+            "longopt" : "token",
+            "help" : "-t, --token=[token]                                   OVH Oauth token ",
+            "required" : "1",
+            "shortdesc" : "OVH Oauth token ",
+            "order" : 3}
+    all_opt["region"] = {
+            "getopt" : "r:",
+            "longopt" : "region",
+            "help" : "-r, --region=[region]                                 OVH region (example: ovh-ca)",
+            "required" : "1",
+            "shortdesc" : "OVH region",
+            "order" : 4}
+    all_opt["service_name"] = {
+            "getopt" : "n:",
+            "longopt" : "service-name",
+            "help" : "-n, --service-name=[service-name]                     OVH service name",
+            "required" : "1",
+            "shortdesc" : "OVH service name",
+            "order" : 5}
+    all_opt["instance_id"] = {
+            "getopt" : "i:",
+            "longopt" : "instance-id",
+            "help" : "-i, --instance-id=[instance-id]                       OVH instance id",
+            "required" : "1",
+            "shortdesc" : "OVH service name",
+            "order" : 6}
+
+def ovh_login(options):
+    session = ovh.Client(
+        endpoint=options["--region"],
+        application_key=options["--application-key"],
+        application_secret=options["--application-secret"],
+        consumer_key=options["--token"],
+    )
+    options["session"] = session;
+    return session;
+
+def status(options, expected_status):
+    session = options["session"]
+    status_url = "/cloud/project/%s/instance/%s" % (options['--service-name'], options['--instance-id'])
+    response = session.get(status_url)
+    return True if response["status"] == expected_status else False
+
+def main():
+    atexit.register(atexit_handler)
+
+    device_opt = ["application_key", "application_secret", "token", "region", "service_name", "instance_id", "no_password"]
+
+    define_new_opts()
+    options = check_input(device_opt, process_input(device_opt), other_conditions=True)
+
+    docs = {}
+    docs["shortdesc"] = "Fence agent for OVH Cloud (REST API)"
+    docs["longdesc"] = "Fence agent for OVH Cloud (REST API) with authentication via Oauth"
+    docs["vendorurl"] = "https://api.ovh.com/"
+    show_docs(options, docs)
+
+    run_delay(options)
+
+    session = ovh_login(options);
+
+    if options["--action"] == "off":
+        try:
+            url = "/cloud/project/%s/instance/%s/rescueMode" % (options['--service-name'], options['--instance-id'])
+            response = session.post(url, rescue=True)
+            if response["adminPassword"] != None:
+                result = 1
+            while not status(options, "RESCUE"):
+                time.sleep(POLL_INTERVAL_SECONDS)
+        except ovh.exceptions.BadParametersError as exception:
+            print(exception)
+            result = 0
+        except Exception as exception:
+            print(exception)
+            result = 0
+
+    if options["--action"] == "on":
+        try:
+            url = "/cloud/project/%s/instance/%s/rescueMode" % (options['--service-name'], options['--instance-id'])
+            response = session.post(url, rescue=False)
+            if response["adminPassword"] == None:
+                result = 1
+            while not status(options, "ACTIVE"):
+                time.sleep(POLL_INTERVAL_SECONDS)
+        except ovh.exceptions.BadParametersError as exception:
+            print(exception)
+            result = 0
+        except Exception as exception:
+            print(exception)
+            result = 0
+
+    sys.exit(result)
+
+if __name__ == "__main__":
+	main()

--- a/agents/ovh_cloud_rest/fence_ovh_cloud_rest.py
+++ b/agents/ovh_cloud_rest/fence_ovh_cloud_rest.py
@@ -88,10 +88,11 @@ def main():
 
     session = ovh_login(options);
 
+    rescue_url = "/cloud/project/%s/instance/%s/rescueMode" % (options['--service-name'], options['--instance-id'])
+
     if options["--action"] == "off":
         try:
-            url = "/cloud/project/%s/instance/%s/rescueMode" % (options['--service-name'], options['--instance-id'])
-            response = session.post(url, rescue=True)
+            response = session.post(rescue_url, rescue=True)
             if response["adminPassword"] != None:
                 result = 1
             while not status(options, "RESCUE"):
@@ -102,8 +103,7 @@ def main():
 
     if options["--action"] == "on":
         try:
-            url = "/cloud/project/%s/instance/%s/rescueMode" % (options['--service-name'], options['--instance-id'])
-            response = session.post(url, rescue=False)
+            response = session.post(rescue_url, rescue=False)
             if response["adminPassword"] == None:
                 result = 1
             while not status(options, "ACTIVE"):

--- a/agents/ovh_cloud_rest/fence_ovh_cloud_rest.py
+++ b/agents/ovh_cloud_rest/fence_ovh_cloud_rest.py
@@ -96,9 +96,6 @@ def main():
                 result = 1
             while not status(options, "RESCUE"):
                 time.sleep(POLL_INTERVAL_SECONDS)
-        except ovh.exceptions.BadParametersError as exception:
-            print(exception)
-            result = 0
         except Exception as exception:
             print(exception)
             result = 0
@@ -111,9 +108,6 @@ def main():
                 result = 1
             while not status(options, "ACTIVE"):
                 time.sleep(POLL_INTERVAL_SECONDS)
-        except ovh.exceptions.BadParametersError as exception:
-            print(exception)
-            result = 0
         except Exception as exception:
             print(exception)
             result = 0


### PR DESCRIPTION
This adds an agent for the OVH Cloud servers via the REST API. The REST API uses Oauth for authentication. Because of the authentication method, the agent ends up expecting an application key, an application secret and a consumer key or token. Getting/creating these values is explained at [First Steps with the API](https://api.ovh.com/g934.first_step_with_api). When creating the consumer key or token, it's important to select the option that disables expiration of it. Noting this here as it was unclear where this kind of documentation should go.

I'm also a bit unclear on the metadata aspect however I've implemented both `on` and `off` (with polling to verify status before it exits with return value `0` or `1`).