### PR TITLE
fence_scsi: don't duplicate entries in /var/run/cluster/fence_scsi.dev

### DIFF
--- a/agents/scsi/fence_scsi.py
+++ b/agents/scsi/fence_scsi.py
@@ -234,7 +234,7 @@ def dev_write(dev, options):
 	except IOError:
 		fail_usage("Failed: Cannot open file \""+ file_path + "\"")
 	out = f.read()
-	if not re.search(r"^" + dev + "\s+", out):
+	if not re.search(r"^" + dev + "\s+", out, flags=re.MULTILINE):
 		f.write(dev + "\n")
 	f.close()
 


### PR DESCRIPTION
Hello

This PR adds the `re.MULTILINE` flag when matching the devices that needs to be written to `/var/run/cluster/fence_scsi.dev`.

https://github.com/ClusterLabs/fence-agents/blob/fe67112688266960d2ff4aac237477fd711be659/agents/scsi/fence_scsi.py#L237

Currently when there is more than one device already in `/var/run/cluster/fence_scsi.dev` file, then the above condition will match only the first device. If there are multiple devices for `fence_scsi` then they will get duplicated over time and file content will start look like below.

~~~
/dev/sdb
/dev/sdc
/dev/sdc
/dev/sdd
~~~
Above is result of:
- configuring `fence_scsi` with `/dev/sdb` and `/dev/sdc`, 
- then changing it to `/dev/sdb`,`/dev/sdc` and `/dev/sdd`. 

Below is example how the output will look after applying this PR (no duplicated lines).
~~~
/dev/sdb
/dev/sdc
/dev/sdd
~~~