### PR TITLE
fence_scsi: fix python3 encoding error #206

### DIFF
--- a/agents/scsi/fence_scsi.py
+++ b/agents/scsi/fence_scsi.py
@@ -181,11 +181,11 @@ def get_cluster_id(options):
 		fail_usage("Failed: cannot get cluster name")
 
 	try:
-		return hashlib.md5(match.group(1)).hexdigest()
+		return hashlib.md5(match.group(1).encode('ascii')).hexdigest()
 	except ValueError:
 		# FIPS requires usedforsecurity=False and might not be
 		# available on all distros: https://bugs.python.org/issue9216
-		return hashlib.md5(match.group(1), usedforsecurity=False).hexdigest()
+		return hashlib.md5(match.group(1).encode('ascii'), usedforsecurity=False).hexdigest()
 
 
 def get_node_id(options):


### PR DESCRIPTION
File "/usr/sbin/fence_scsi", line 184, in get_cluster_id
  return hashlib.md5(match.group(1)).hexdigest()
TypeError: Unicode-objects must be encoded before hashing