### PR TITLE
fence_gce: logging and non required parameters

### DIFF
--- a/agents/gce/fence_gce.py
+++ b/agents/gce/fence_gce.py
@@ -2,9 +2,18 @@
 
 import atexit
 import logging
+import os
 import platform
 import sys
 import time
+if sys.version_info >= (3, 0):
+  # Python 3 imports.
+  import urllib.parse as urlparse
+  import urllib.request as urlrequest
+else:
+  # Python 2 imports.
+  import urllib as urlparse
+  import urllib2 as urlrequest
 sys.path.append("@FENCEAGENTSLIBDIR@")
 
 import googleapiclient.discovery

--- a/agents/gce/fence_gce.py
+++ b/agents/gce/fence_gce.py
@@ -1,11 +1,18 @@
 #!@PYTHON@ -tt
 
 import atexit
+import logging
+import platform
 import sys
+import time
 sys.path.append("@FENCEAGENTSLIBDIR@")
 
 import googleapiclient.discovery
 from fencing import fail_usage, run_delay, all_opt, atexit_handler, check_input, process_input, show_docs, fence_action
+
+
+LOGGER = logging
+
 
 def translate_status(instance_status):
 	"Returns on | off | unknown."
@@ -27,6 +34,7 @@ def get_nodes_list(conn, options):
 
 	return result
 
+
 def get_power_status(conn, options):
 	try:
 		instance = conn.instances().get(
@@ -38,18 +46,37 @@ def get_power_status(conn, options):
 		fail_usage("Failed: get_power_status: {}".format(str(err)))
 
 
+def wait_for_operation(conn, project, zone, operation):
+	while True:
+		result = conn.zoneOperations().get(
+			project=project,
+			zone=zone,
+			operation=operation['name']).execute()
+		if result['status'] == 'DONE':
+			if 'error' in result:
+				raise Exception(result['error'])
+			return
+		time.sleep(1)
+
+
 def set_power_status(conn, options):
 	try:
 		if options["--action"] == "off":
-			conn.instances().stop(
+			LOGGER.info("Issuing poweroff of %s in zone %s" % (options["--plug"], options["--zone"]))
+			operation = conn.instances().stop(
 					project=options["--project"],
 					zone=options["--zone"],
 					instance=options["--plug"]).execute()
+			wait_for_operation(conn, options["--project"], options["--zone"], operation)
+			LOGGER.info("Poweroff of %s in zone %s complete" % (options["--plug"], options["--zone"]))
 		elif options["--action"] == "on":
-			conn.instances().start(
+			LOGGER.info("Issuing poweron of %s in zone %s" % (options["--plug"], options["--zone"]))
+			operation = conn.instances().start(
 					project=options["--project"],
 					zone=options["--zone"],
 					instance=options["--plug"]).execute()
+			wait_for_operation(conn, options["--project"], options["--zone"], operation)
+			LOGGER.info("Poweron of %s in zone %s complete" % (options["--plug"], options["--zone"]))
 	except Exception as err:
 		fail_usage("Failed: set_power_status: {}".format(str(err)))
 
@@ -71,11 +98,24 @@ def define_new_opts():
 		"required" : "1",
 		"order" : 3
 	}
+	all_opt["logging"] = {
+		"getopt" : ":",
+		"longopt" : "logging",
+		"help" : "--logging=[bool]               Logging, true/false",
+		"shortdesc" : "Stackdriver-logging support.",
+		"longdesc" : "If enabled (set to true), IP failover logs will be posted to stackdriver logging.",
+		"required" : "0",
+		"default" : "false",
+		"order" : 4
+	}
 
 def main():
 	conn = None
+	global LOGGER
 
-	device_opt = ["port", "no_password", "zone", "project"]
+	hostname = platform.node()
+
+	device_opt = ["port", "no_password", "zone", "project", "logging"]
 
 	atexit.register(atexit_handler)
 
@@ -97,6 +137,25 @@ def main():
 
 	run_delay(options)
 
+	# Prepare logging
+	logging_env = options.get('--logging')
+	if logging_env:
+		logging_env = logging_env.lower()
+		if any(x in logging_env for x in ['yes', 'true', 'enabled']):
+			try:
+				import google.cloud.logging.handlers
+				client = google.cloud.logging.Client()
+				handler = google.cloud.logging.handlers.CloudLoggingHandler(client, name=hostname)
+				formatter = logging.Formatter('gcp:stonish "%(message)s"')
+				LOGGER = logging.getLogger(hostname)
+				handler.setFormatter(formatter)
+				LOGGER.addHandler(handler)
+				LOGGER.setLevel(logging.INFO)
+			except ImportError:
+				LOGGER.error('Couldn\'t import google.cloud.logging, '
+					'disabling Stackdriver-logging support')
+
+	# Prepare cli
 	try:
 		credentials = None
 		if tuple(googleapiclient.__version__) < tuple("1.6.0"):

--- a/agents/gce/fence_gce.py
+++ b/agents/gce/fence_gce.py
@@ -167,14 +167,13 @@ def define_new_opts():
 		"required" : "0",
 		"order" : 3
 	}
-	all_opt["logging"] = {
-		"getopt" : ":",
-		"longopt" : "logging",
-		"help" : "--logging=[bool]               Logging, true/false",
+	all_opt["stackdriver-logging"] = {
+		"getopt" : "",
+		"longopt" : "stackdriver-logging",
+		"help" : "--stackdriver-logging		Enable Logging to Stackdriver",
 		"shortdesc" : "Stackdriver-logging support.",
-		"longdesc" : "If enabled (set to true), IP failover logs will be posted to stackdriver logging.",
+		"longdesc" : "If enabled IP failover logs will be posted to stackdriver logging.",
 		"required" : "0",
-		"default" : "false",
 		"order" : 4
 	}
 
@@ -185,7 +184,7 @@ def main():
 
 	hostname = platform.node()
 
-	device_opt = ["port", "no_password", "zone", "project", "logging", "method"]
+	device_opt = ["port", "no_password", "zone", "project", "stackdriver-logging", "method"]
 
 	atexit.register(atexit_handler)
 
@@ -210,22 +209,19 @@ def main():
 	run_delay(options)
 
 	# Prepare logging
-	logging_env = options.get('--logging')
-	if logging_env:
-		logging_env = logging_env.lower()
-		if any(x in logging_env for x in ['yes', 'true', 'enabled']):
-			try:
-				import google.cloud.logging.handlers
-				client = google.cloud.logging.Client()
-				handler = google.cloud.logging.handlers.CloudLoggingHandler(client, name=hostname)
-				formatter = logging.Formatter('gcp:stonish "%(message)s"')
-				LOGGER = logging.getLogger(hostname)
-				handler.setFormatter(formatter)
-				LOGGER.addHandler(handler)
-				LOGGER.setLevel(logging.INFO)
-			except ImportError:
-				LOGGER.error('Couldn\'t import google.cloud.logging, '
-					'disabling Stackdriver-logging support')
+	if options.get('--stackdriver-logging'):
+		try:
+			import google.cloud.logging.handlers
+			client = google.cloud.logging.Client()
+			handler = google.cloud.logging.handlers.CloudLoggingHandler(client, name=hostname)
+			formatter = logging.Formatter('gcp:stonish "%(message)s"')
+			LOGGER = logging.getLogger(hostname)
+			handler.setFormatter(formatter)
+			LOGGER.addHandler(handler)
+			LOGGER.setLevel(logging.INFO)
+		except ImportError:
+			LOGGER.error('Couldn\'t import google.cloud.logging, '
+				'disabling Stackdriver-logging support')
 
 	# Prepare cli
 	try:

--- a/tests/data/metadata/fence_gce.xml
+++ b/tests/data/metadata/fence_gce.xml
@@ -10,6 +10,14 @@ For instructions see: https://cloud.google.com/compute/docs/tutorials/python-gui
 		<content type="string" default="reboot"  />
 		<shortdesc lang="en">Fencing action</shortdesc>
 	</parameter>
+	<parameter name="method" unique="0" required="0">
+		<getopt mixed="-m, --method=[method]" />
+		<content type="select" default="cycle"  >
+			<option value="onoff" />
+			<option value="cycle" />
+		</content>
+		<shortdesc lang="en">Method to fence</shortdesc>
+	</parameter>
 	<parameter name="plug" unique="0" required="1" obsoletes="port">
 		<getopt mixed="-n, --plug=[id]" />
 		<content type="string"  />

--- a/tests/data/metadata/fence_gce.xml
+++ b/tests/data/metadata/fence_gce.xml
@@ -20,12 +20,12 @@ For instructions see: https://cloud.google.com/compute/docs/tutorials/python-gui
 		<content type="string"  />
 		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
 	</parameter>
-	<parameter name="zone" unique="0" required="1">
+	<parameter name="zone" unique="0" required="0">
 		<getopt mixed="--zone=[name]" />
 		<content type="string"  />
 		<shortdesc lang="en">Zone.</shortdesc>
 	</parameter>
-	<parameter name="project" unique="0" required="1">
+	<parameter name="project" unique="0" required="0">
 		<getopt mixed="--project=[name]" />
 		<content type="string"  />
 		<shortdesc lang="en">Project ID.</shortdesc>

--- a/tests/data/metadata/fence_gce.xml
+++ b/tests/data/metadata/fence_gce.xml
@@ -30,6 +30,11 @@ For instructions see: https://cloud.google.com/compute/docs/tutorials/python-gui
 		<content type="string"  />
 		<shortdesc lang="en">Project ID.</shortdesc>
 	</parameter>
+	<parameter name="logging" unique="0" required="0">
+		<getopt mixed="--logging=[bool]" />
+		<content type="string" default="false"  />
+		<shortdesc lang="en">Stackdriver-logging support.</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />

--- a/tests/data/metadata/fence_gce.xml
+++ b/tests/data/metadata/fence_gce.xml
@@ -38,9 +38,14 @@ For instructions see: https://cloud.google.com/compute/docs/tutorials/python-gui
 		<content type="string"  />
 		<shortdesc lang="en">Project ID.</shortdesc>
 	</parameter>
-	<parameter name="logging" unique="0" required="0">
-		<getopt mixed="--logging=[bool]" />
-		<content type="string" default="false"  />
+	<parameter name="stackdriver-logging" unique="0" required="0" deprecated="1">
+		<getopt mixed="--stackdriver-logging" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Stackdriver-logging support.</shortdesc>
+	</parameter>
+	<parameter name="stackdriver_logging" unique="0" required="0" obsoletes="stackdriver-logging">
+		<getopt mixed="--stackdriver-logging" />
+		<content type="boolean"  />
 		<shortdesc lang="en">Stackdriver-logging support.</shortdesc>
 	</parameter>
 	<parameter name="quiet" unique="0" required="0">


### PR DESCRIPTION
The following changes were made provide some of the features supported by the following script:  https://storage.googleapis.com/sapdeploy/pacemaker-gcp/gcpstonith

fence_gce: add support for stackdriver logging
Add --logging option to enable sending logs to google stackdriver

fence_gce: set project and zone as not required

Try to retrieve the GCE project if the script is being executed inside a
GCE machine if --project is not provided.
Try to retrieve the zone automatically from GCE if --zone is not
provided.
