### PR TITLE
fence_kdump: fix strncpy issue

### DIFF
--- a/agents/kdump/fence_kdump.c
+++ b/agents/kdump/fence_kdump.c
@@ -351,7 +351,7 @@ get_options_node (fence_kdump_opts_t *opts)
     hints.ai_protocol = IPPROTO_UDP;
     hints.ai_flags = AI_NUMERICSERV;
 
-    strncpy (node->name, opts->nodename, sizeof (node->name));
+    strncpy (node->name, opts->nodename, sizeof (node->name) - 1);
     snprintf (node->port, sizeof (node->port), "%d", opts->ipport);
 
     node->info = NULL;

--- a/agents/kdump/fence_kdump_send.c
+++ b/agents/kdump/fence_kdump_send.c
@@ -116,7 +116,7 @@ get_options_node (fence_kdump_opts_t *opts)
     hints.ai_protocol = IPPROTO_UDP;
     hints.ai_flags = AI_NUMERICSERV;
 
-    strncpy (node->name, opts->nodename, sizeof (node->name));
+    strncpy (node->name, opts->nodename, sizeof (node->name) - 1);
     snprintf (node->port, sizeof (node->port), "%d", opts->ipport);
 
     node->info = NULL;


### PR DESCRIPTION
fence-agents-4.2.1/agents/kdump/fence_kdump.c:354: buffer_size_warning: Calling strncpy with a maximum size argument of 256 bytes on destination array "node->name" of size 256 bytes might leave the destination string unterminated.
fence-agents-4.2.1/agents/kdump/fence_kdump_send.c:119: buffer_size_warning: Calling strncpy with a maximum size argument of 256 bytes on destination array "node->name" of size 256 bytes might leave the destination string unterminated.