### PR TITLE
The help for the fence_rhevm -n (--plug) parameter is incorrect.

### DIFF
--- a/agents/rhevm/fence_rhevm.py
+++ b/agents/rhevm/fence_rhevm.py
@@ -136,6 +136,14 @@ def send_command(opt, command, method="GET"):
 	return result
 
 def define_new_opts():
+
+	all_opt["port"] = {
+		"getopt" : "n:",
+		"longopt" : "plug",
+		"help" : "-n, --plug=[name]              "
+		"The VM name in RHV",
+		"required" : "1",
+		"order" : 1}
 	all_opt["use_cookies"] = {
 		"getopt" : "",
 		"longopt" : "use-cookies",

--- a/tests/data/metadata/fence_rhevm.xml
+++ b/tests/data/metadata/fence_rhevm.xml
@@ -64,14 +64,14 @@
 		<shortdesc lang="en">Script to run to retrieve password</shortdesc>
 	</parameter>
 	<parameter name="plug" unique="0" required="1" obsoletes="port">
-		<getopt mixed="-n, --plug=[id]" />
+		<getopt mixed="-n, --plug=[name]" />
 		<content type="string"  />
-		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
+		<shortdesc lang="en">The VM name in RHV</shortdesc>
 	</parameter>
 	<parameter name="port" unique="0" required="1" deprecated="1">
-		<getopt mixed="-n, --plug=[id]" />
+		<getopt mixed="-n, --plug=[name]" />
 		<content type="string"  />
-		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
+		<shortdesc lang="en">The VM name in RHV</shortdesc>
 	</parameter>
 	<parameter name="ssl" unique="0" required="0">
 		<getopt mixed="-z, --ssl" />


### PR DESCRIPTION
The help for the fence_rhevm -n (--plug) parameter is incorrect.

The current help is :

 -n, --plug=[id]                Physical plug number on device, UUID or
                                        identification of machine
should be

-n, --plug=[name]		The VM name in RHV

The fence_rhevm using the VM name passed in order to get the UUID of
that VM such that the VM can be stopped/started user REST API

<url>/vms/<vm uuid>/stop or <url>/vms/<vm uuid>/start

Issue : https://github.com/ClusterLabs/fence-agents/issues/224
Signed-off-by: emesika <emesika@redhat.com>