### PR TITLE
fence-rhevm: improve error reporting.

### DIFF
--- a/agents/rhevm/fence_rhevm.py
+++ b/agents/rhevm/fence_rhevm.py
@@ -6,7 +6,7 @@ import logging
 import atexit
 sys.path.append("@FENCEAGENTSLIBDIR@")
 from fencing import *
-from fencing import fail, EC_STATUS, run_delay
+from fencing import fail, EC_FETCH_VM_UUID, run_delay
 
 RE_GET_ID = re.compile("<vm( .*)? id=\"(.*?)\"", re.IGNORECASE)
 RE_STATUS = re.compile("<state>(.*?)</state>", re.IGNORECASE)
@@ -21,7 +21,7 @@ def get_power_status(conn, options):
 	result = RE_GET_ID.search(res)
 	if result == None:
 		# Unable to obtain ID needed to access virtual machine
-		fail(EC_STATUS)
+		fail(EC_FETCH_VM_UUID)
 
 	options["id"] = result.group(2)
 

--- a/lib/fencing.py.py
+++ b/lib/fencing.py.py
@@ -27,6 +27,7 @@ EC_STATUS = 8
 EC_STATUS_HMC = 9
 EC_PASSWORD_MISSING = 10
 EC_INVALID_PRIVILEGES = 11
+EC_FETCH_VM_UUID = 12
 
 LOG_FORMAT = "%(asctime)-15s %(levelname)s: %(message)s"
 
@@ -540,7 +541,9 @@ def fail(error_code):
 		EC_STATUS_HMC : "Failed: Either unable to obtain correct plug status, "
 				"partition is not available or incorrect HMC version used",
 		EC_PASSWORD_MISSING : "Failed: You have to set login password",
-		EC_INVALID_PRIVILEGES : "Failed: The user does not have the correct privileges to do the requested action."
+		EC_INVALID_PRIVILEGES : "Failed: The user does not have the correct privileges to do the requested action.",
+		EC_FETCH_VM_UUID : "Failed: Can not find VM UUID by its VM name given in the <plug> parameter."
+
 	}[error_code] + "\n"
 	logging.error("%s\n", message)
 	sys.exit(EC_GENERIC_ERROR)


### PR DESCRIPTION
fence_rhevm uses REST API to call RHV

In fence_rhevm , the plug parameter is actually the VN name and is used
in order to construct a REST API search request to get the VM UUID from
RHV by the VM name.
In case that the call fails an unrelated error is displayed

"Failed: Unable to obtain correct plug status or plug is not available"

Code should be changed to output a clear error in case that the REST API fail

Issue : #225
Signed-off-by: emesika emesika@redhat.com