### PR TITLE
Update fence_rcd_serial to correct vendor URL

### DIFF
--- a/agents/rcd_serial/fence_rcd_serial.py
+++ b/agents/rcd_serial/fence_rcd_serial.py
@@ -1,12 +1,12 @@
 #!@PYTHON@ -tt
 
-# Copyright 2015 Infoxchange, Danielle Madeley, Sam McLeod-Jones
+# Copyright 2018 Infoxchange, Danielle Madeley, Sam McLeod-Jones
 
 # Controls an RCD serial device
 # Ported from stonith/rcd_serial.c
 
 # The Following Agent Has Been Tested On:
-# CentOS Linux release 7.1.1503
+# CentOS Linux release 7.5.1804
 
 # Resource example:
 # primitive stonith_node_1 ocf:rcd_serial_py params port="/dev/ttyS0" time=1000 hostlist=stonith_node_1 stonith-timeout=5s
@@ -82,7 +82,7 @@ reset of an opposing server using the reset switch on its motherboard. The \
 cable itself is simple with no power, network or moving parts. An example of \
 the cable is available here: https://smcleod.net/rcd-stonith/ and the circuit \
 design is available in the fence-agents src as SVG"
-	docs["vendorurl"] = "http://www.scl.co.uk/rcd_serial/"
+	docs["vendorurl"] = "https://github.com/sammcj/fence_rcd_serial"
 	show_docs(options, docs)
 
 	if options["--action"] in ["off", "reboot"]:

--- a/tests/data/metadata/fence_rcd_serial.xml
+++ b/tests/data/metadata/fence_rcd_serial.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <resource-agent name="fence_rcd_serial" shortdesc="rcd_serial fence agent" >
 <longdesc>fence_rcd_serial operates a serial cable that toggles a reset of an opposing server using the reset switch on its motherboard. The cable itself is simple with no power, network or moving parts. An example of the cable is available here: https://smcleod.net/rcd-stonith/ and the circuit design is available in the fence-agents src as SVG</longdesc>
-<vendor-url>http://www.scl.co.uk/rcd_serial/</vendor-url>
+<vendor-url>https://github.com/sammcj/fence_rcd_serial</vendor-url>
 <parameters>
 	<parameter name="action" unique="0" required="1">
 		<getopt mixed="-o, --action=[action]" />


### PR DESCRIPTION
* Correct vendor URL to https://github.com/sammcj/fence_rcd_serial
* Update RHEL/CentOS version currently agent currently tested with
* Update Copyright date

For more information on this provider, see: https://smcleod.net/tech/2016/07/04/update-rcd-stonith-design.html