### PR TITLE
fencing: improve stdin parse function

### DIFF
--- a/lib/fencing.py.py
+++ b/lib/fencing.py.py
@@ -1389,6 +1389,7 @@ def _parse_input_stdin(avail_opt):
 
 		(name, value) = (line + "=").split("=", 1)
 		value = value[:-1]
+		value = re.sub("^\"(.*)\"$", "\\1", value)
 
 		if name.replace("-", "_") in mapping_longopt_names:
 			name = mapping_longopt_names[name.replace("-", "_")]


### PR DESCRIPTION
- Remove quotes around stdin parameters for consistency with CLI
parameters and to be able to quote number and time parameters