### PR TITLE
fence_pve: add support for sending reset command to qemu machines

### DIFF
--- a/agents/pve/fence_pve.py
+++ b/agents/pve/fence_pve.py
@@ -56,7 +56,7 @@ def set_power_status(conn, options):
 
 def reboot_cycle(conn, options):
 	del conn
-	cmd = "nodes/" + options["--nodename"] + "/qemu/" + options["--plug"] + "/status/reset"
+	cmd = "nodes/" + options["--nodename"] + "/" + options["--vmtype"] + "/" + options["--plug"] + "/status/reset"
 	result = send_cmd(options, cmd, post={"skiplock":1})
 	return type(result) is dict and "data" in result
 
@@ -183,6 +183,10 @@ machines acting as nodes in a virtualized cluster."
 
 	if "--nodename" not in options or not options["--nodename"]:
 		options["--nodename"] = None
+
+	if options["--vmtype"] != "qemu":
+		# For vmtypes other than qemu, only the onoff method is valid
+		options["--method"] = "onoff"
 
 	options["url"] = "https://" + options["--ip"] + ":" + str(options["--ipport"]) + "/api2/json/"
 

--- a/agents/pve/fence_pve.py
+++ b/agents/pve/fence_pve.py
@@ -54,6 +54,13 @@ def set_power_status(conn, options):
 	send_cmd(options, cmd, post={"skiplock":1})
 
 
+def reboot_cycle(conn, options):
+	del conn
+	cmd = "nodes/" + options["--nodename"] + "/qemu/" + options["--plug"] + "/status/reset"
+	result = send_cmd(options, cmd, post={"skiplock":1})
+	return type(result) is dict and "data" in result
+
+
 def get_outlet_list(conn, options):
 	del conn
 	nodes = send_cmd(options, "nodes")
@@ -154,7 +161,7 @@ def main():
 		"order": 2
 	}
 
-	device_opt = ["ipaddr", "login", "passwd", "web", "port", "node_name", "vmtype"]
+	device_opt = ["ipaddr", "login", "passwd", "web", "port", "node_name", "vmtype", "method"]
 
 	all_opt["login"]["required"] = "0"
 	all_opt["login"]["default"] = "root@pam"
@@ -186,10 +193,10 @@ machines acting as nodes in a virtualized cluster."
 	# Workaround for unsupported API call on some Proxmox hosts
 	outlets = get_outlet_list(None, options)        # Unsupported API-Call will result in value: None
 	if outlets is None:
-		result = fence_action(None, options, set_power_status, get_power_status, None)
+		result = fence_action(None, options, set_power_status, get_power_status, None, reboot_cycle)
 		sys.exit(result)
 
-	result = fence_action(None, options, set_power_status, get_power_status, get_outlet_list)
+	result = fence_action(None, options, set_power_status, get_power_status, get_outlet_list, reboot_cycle)
 
 	sys.exit(result)
 

--- a/tests/data/metadata/fence_pve.xml
+++ b/tests/data/metadata/fence_pve.xml
@@ -38,6 +38,14 @@
 		<content type="string" default="root@pam"  />
 		<shortdesc lang="en">Login name</shortdesc>
 	</parameter>
+	<parameter name="method" unique="0" required="0">
+		<getopt mixed="-m, --method=[method]" />
+		<content type="select" default="onoff"  >
+			<option value="onoff" />
+			<option value="cycle" />
+		</content>
+		<shortdesc lang="en">Method to fence</shortdesc>
+	</parameter>
 	<parameter name="passwd" unique="0" required="0" deprecated="1">
 		<getopt mixed="-p, --password=[password]" />
 		<content type="string"  />


### PR DESCRIPTION
Restarting VMs by sending poweroff and poweron commands is slow and unreliable; machines may hang or time out during shutdown.

A better option, at least for qemu VMs, is to send a "reset" command. This immediately reboots the VM, just like pressing the reset button on a physical server.

This patch implements the required changes. The new reboot code is activated by providing the option method=cycle.