### PR TITLE
fence_ipmilan: Add ipmitool timeout option

### DIFF
--- a/agents/ipmilan/fence_ipmilan.py
+++ b/agents/ipmilan/fence_ipmilan.py
@@ -86,6 +86,9 @@ def create_command(options, action):
 	if "--hexadecimal-kg" in options:
 		Cmd.append(" -y " + options["--hexadecimal-kg"])
 
+	if "--ipmitool-timeout" in options:
+		Cmd.append(" -N " + options["--ipmitool-timeout"])
+
 	# --action / -o
 	Cmd.append(" chassis power " + action)
 
@@ -138,6 +141,15 @@ def define_new_opts():
 		"default" : "@IPMITOOL_PATH@",
 		"order": 200
 	}
+	all_opt["ipmitool_timeout"] = {
+		"getopt" : ":",
+		"longopt" : "ipmitool-timeout",
+		"help" : "--ipmitool-timeout=[timeout]         Timeout (sec) for IPMI operation",
+		"required" : "0",
+		"shortdesc" : "Timeout (sec) for IPMI operation",
+		"default" : "2",
+		"order": 201
+	}
 	all_opt["target"] = {
 		"getopt" : ":",
 		"longopt" : "target",
@@ -160,7 +172,7 @@ def main():
 
 	device_opt = ["ipaddr", "login", "no_login", "no_password", "passwd",
 		"diag", "lanplus", "auth", "cipher", "privlvl", "sudo",
-		"ipmitool_path", "method", "target", "hexadecimal_kg"]
+		"ipmitool_path", "ipmitool_timeout", "method", "target", "hexadecimal_kg"]
 	define_new_opts()
 
 	all_opt["power_wait"]["default"] = 2

--- a/tests/data/metadata/fence_idrac.xml
+++ b/tests/data/metadata/fence_idrac.xml
@@ -189,6 +189,11 @@
 		<content type="second" default="3"  />
 		<shortdesc lang="en">Wait X seconds for cmd prompt after issuing command</shortdesc>
 	</parameter>
+	<parameter name="ipmitool_timeout" unique="0" required="0">
+		<getopt mixed="--ipmitool-timeout=[timeout]" />
+		<content type="string" default="2"  />
+		<shortdesc lang="en">Timeout (sec) for IPMI operation</shortdesc>
+	</parameter>
 	<parameter name="retry_on" unique="0" required="0">
 		<getopt mixed="--retry-on=[attempts]" />
 		<content type="integer" default="1"  />

--- a/tests/data/metadata/fence_ilo3.xml
+++ b/tests/data/metadata/fence_ilo3.xml
@@ -189,6 +189,11 @@
 		<content type="second" default="3"  />
 		<shortdesc lang="en">Wait X seconds for cmd prompt after issuing command</shortdesc>
 	</parameter>
+	<parameter name="ipmitool_timeout" unique="0" required="0">
+		<getopt mixed="--ipmitool-timeout=[timeout]" />
+		<content type="string" default="2"  />
+		<shortdesc lang="en">Timeout (sec) for IPMI operation</shortdesc>
+	</parameter>
 	<parameter name="retry_on" unique="0" required="0">
 		<getopt mixed="--retry-on=[attempts]" />
 		<content type="integer" default="1"  />

--- a/tests/data/metadata/fence_ilo4.xml
+++ b/tests/data/metadata/fence_ilo4.xml
@@ -189,6 +189,11 @@
 		<content type="second" default="3"  />
 		<shortdesc lang="en">Wait X seconds for cmd prompt after issuing command</shortdesc>
 	</parameter>
+	<parameter name="ipmitool_timeout" unique="0" required="0">
+		<getopt mixed="--ipmitool-timeout=[timeout]" />
+		<content type="string" default="2"  />
+		<shortdesc lang="en">Timeout (sec) for IPMI operation</shortdesc>
+	</parameter>
 	<parameter name="retry_on" unique="0" required="0">
 		<getopt mixed="--retry-on=[attempts]" />
 		<content type="integer" default="1"  />

--- a/tests/data/metadata/fence_ilo5.xml
+++ b/tests/data/metadata/fence_ilo5.xml
@@ -189,6 +189,11 @@
 		<content type="second" default="3"  />
 		<shortdesc lang="en">Wait X seconds for cmd prompt after issuing command</shortdesc>
 	</parameter>
+	<parameter name="ipmitool_timeout" unique="0" required="0">
+		<getopt mixed="--ipmitool-timeout=[timeout]" />
+		<content type="string" default="2"  />
+		<shortdesc lang="en">Timeout (sec) for IPMI operation</shortdesc>
+	</parameter>
 	<parameter name="retry_on" unique="0" required="0">
 		<getopt mixed="--retry-on=[attempts]" />
 		<content type="integer" default="1"  />

--- a/tests/data/metadata/fence_imm.xml
+++ b/tests/data/metadata/fence_imm.xml
@@ -189,6 +189,11 @@
 		<content type="second" default="3"  />
 		<shortdesc lang="en">Wait X seconds for cmd prompt after issuing command</shortdesc>
 	</parameter>
+	<parameter name="ipmitool_timeout" unique="0" required="0">
+		<getopt mixed="--ipmitool-timeout=[timeout]" />
+		<content type="string" default="2"  />
+		<shortdesc lang="en">Timeout (sec) for IPMI operation</shortdesc>
+	</parameter>
 	<parameter name="retry_on" unique="0" required="0">
 		<getopt mixed="--retry-on=[attempts]" />
 		<content type="integer" default="1"  />

--- a/tests/data/metadata/fence_ipmilan.xml
+++ b/tests/data/metadata/fence_ipmilan.xml
@@ -189,6 +189,11 @@
 		<content type="second" default="3"  />
 		<shortdesc lang="en">Wait X seconds for cmd prompt after issuing command</shortdesc>
 	</parameter>
+	<parameter name="ipmitool_timeout" unique="0" required="0">
+		<getopt mixed="--ipmitool-timeout=[timeout]" />
+		<content type="string" default="2"  />
+		<shortdesc lang="en">Timeout (sec) for IPMI operation</shortdesc>
+	</parameter>
 	<parameter name="retry_on" unique="0" required="0">
 		<getopt mixed="--retry-on=[attempts]" />
 		<content type="integer" default="1"  />


### PR DESCRIPTION
The default ipmitool timeout in some versions is
extremely short (on the order of 1s), and in
newer versions it is 2s by default.

This commit adds an option to configure the
timeout, and sets the default timeout to 2s.

Signed-off-by: Kristoffer Gronlund <kgronlund@suse.com>