### PR TITLE
replace hard-to-read formatting marks with quotes where appropriate

### DIFF
--- a/agents/kdump/fence_kdump.c
+++ b/agents/kdump/fence_kdump.c
@@ -206,12 +206,12 @@ do_action_metadata (const char *self)
     fprintf (stdout, "<resource-agent name=\"%s\"", basename (self));
     fprintf (stdout, " shortdesc=\"fencing agent for use with kdump crash recovery service\">\n");
     fprintf (stdout, "<longdesc>");
-    fprintf (stdout, "\\fIfence_kdump\\fP is an I/O fencing agent to be used with the kdump\n"
-                     "crash recovery service. When the \\fIfence_kdump\\fP agent is invoked,\n"
+    fprintf (stdout, "fence_kdump is an I/O fencing agent to be used with the kdump\n"
+                     "crash recovery service. When the fence_kdump agent is invoked,\n"
                      "it will listen for a message from the failed node that acknowledges\n"
                      "that the failed node it executing the kdump crash kernel.\n"
-                     "Note that \\fIfence_kdump\\fP is not a replacement for traditional\n"
-                     "fencing methods. The \\fIfence_kdump\\fP agent can only detect that a\n"
+                     "Note that fence_kdump is not a replacement for traditional\n"
+                     "fencing methods. The fence_kdump agent can only detect that a\n"
                      "node has entered the kdump crash recovery service. This allows the\n"
                      "kdump crash recovery service complete without being preempted by\n"
                      "traditional power fencing methods.\n\n"
@@ -227,7 +227,7 @@ do_action_metadata (const char *self)
     fprintf (stdout, "<parameters>\n");
 
     fprintf (stdout, "\t<parameter name=\"nodename\" unique=\"0\" required=\"0\">\n");
-    fprintf (stdout, "\t\t<getopt mixed=\"-n, --nodename=\\fINODE\\fP\" />\n");
+    fprintf (stdout, "\t\t<getopt mixed=\"-n, --nodename=NODE\" />\n");
     fprintf (stdout, "\t\t<content type=\"string\" />\n");
     fprintf (stdout, "\t\t<shortdesc lang=\"en\">%s</shortdesc>\n",
              "Name or IP address of node to be fenced. This option is required for\n"
@@ -235,36 +235,36 @@ do_action_metadata (const char *self)
     fprintf (stdout, "\t</parameter>\n");
 
     fprintf (stdout, "\t<parameter name=\"ipport\" unique=\"0\" required=\"0\">\n");
-    fprintf (stdout, "\t\t<getopt mixed=\"-p, --ipport=\\fIPORT\\fP\" />\n");
+    fprintf (stdout, "\t\t<getopt mixed=\"-p, --ipport=PORT\" />\n");
     fprintf (stdout, "\t\t<content type=\"string\" default=\"7410\" />\n");
     fprintf (stdout, "\t\t<shortdesc lang=\"en\">%s</shortdesc>\n",
-             "IP port number that the \\fIfence_kdump\\fP agent will use to listen for\n"
+             "IP port number that the fence_kdump agent will use to listen for\n"
              "messages.");
     fprintf (stdout, "\t</parameter>\n");
 
     fprintf (stdout, "\t<parameter name=\"family\" unique=\"0\" required=\"0\">\n");
-    fprintf (stdout, "\t\t<getopt mixed=\"-f, --family=\\fIFAMILY\\fP\" />\n");
+    fprintf (stdout, "\t\t<getopt mixed=\"-f, --family=FAMILY\" />\n");
     fprintf (stdout, "\t\t<content type=\"string\" default=\"auto\" />\n");
     fprintf (stdout, "\t\t<shortdesc lang=\"en\">%s</shortdesc>\n",
-             "IP network family. Force the \\fIfence_kdump\\fP agent to use a specific\n"
-             "family. The value for \\fIFAMILY\\fP can be \"auto\", \"ipv4\", or\n"
+             "IP network family. Force the fence_kdump agent to use a specific\n"
+             "family. The value for FAMILY can be \"auto\", \"ipv4\", or\n"
              "\"ipv6\".");
     fprintf (stdout, "\t</parameter>\n");
 
     fprintf (stdout, "\t<parameter name=\"action\" unique=\"0\" required=\"0\">\n");
-    fprintf (stdout, "\t\t<getopt mixed=\"-o, --action=\\fIACTION\\fP\" />\n");
+    fprintf (stdout, "\t\t<getopt mixed=\"-o, --action=ACTION\" />\n");
     fprintf (stdout, "\t\t<content type=\"string\" default=\"off\" />\n");
     fprintf (stdout, "\t\t<shortdesc lang=\"en\">%s</shortdesc>\n",
-             "Fencing action to perform. The value for \\fIACTION\\fP can be either\n"
+             "Fencing action to perform. The value for ACTION can be either\n"
              "\"off\" or \"metadata\".");
     fprintf (stdout, "\t</parameter>\n");
 
     fprintf (stdout, "\t<parameter name=\"timeout\" unique=\"0\" required=\"0\">\n");
-    fprintf (stdout, "\t\t<getopt mixed=\"-t, --timeout=\\fITIMEOUT\\fP\" />\n");
+    fprintf (stdout, "\t\t<getopt mixed=\"-t, --timeout=TIMEOUT\" />\n");
     fprintf (stdout, "\t\t<content type=\"string\" default=\"60\" />\n");
     fprintf (stdout, "\t\t<shortdesc lang=\"en\">%s</shortdesc>\n",
              "Number of seconds to wait for message from failed node. If no message\n"
-             "is received within \\fITIMEOUT\\fP seconds, the \\fIfence_kdump\\fP agent\n"
+             "is received within TIMEOUT seconds, the fence_kdump agent\n"
              "returns failure.");
     fprintf (stdout, "\t</parameter>\n");
 

--- a/lib/fencing.py.py
+++ b/lib/fencing.py.py
@@ -572,7 +572,7 @@ def metadata(options, avail_opt, docs):
 	sorted_list.sort(key=lambda x: (x[1]["order"], x[0]))
 
 	if options["--action"] == "metadata":
-		docs["longdesc"] = re.sub("\.P|\.TP|\.br\n", "", docs["longdesc"])
+               docs["longdesc"] = re.sub("\\\\f[BPIR]|\.P|\.TP|\.br\n", "", docs["longdesc"])
 
 	print("<?xml version=\"1.0\" ?>")
 	print("<resource-agent name=\"" + os.path.basename(sys.argv[0]) + \

--- a/tests/data/metadata/fence_kdump.xml
+++ b/tests/data/metadata/fence_kdump.xml
@@ -1,37 +1,54 @@
 <?xml version="1.0" ?>
-<resource-agent name="fence_kdump" shortdesc="Fence agent for use with kdump">
-<longdesc>The fence_kdump agent is intended to be used with with kdump service.</longdesc>
+<resource-agent name="fence_kdump" shortdesc="fencing agent for use with kdump crash recovery service">
+<longdesc>fence_kdump is an I/O fencing agent to be used with the kdump
+crash recovery service. When the fence_kdump agent is invoked,
+it will listen for a message from the failed node that acknowledges
+that the failed node it executing the kdump crash kernel.
+Note that fence_kdump is not a replacement for traditional
+fencing methods. The fence_kdump agent can only detect that a
+node has entered the kdump crash recovery service. This allows the
+kdump crash recovery service complete without being preempted by
+traditional power fencing methods.
+
+Note: the "off" action listen for message from failed node that
+acknowledges node has entered kdump crash recovery service. If a valid
+message is received from the failed node, the node is considered to be
+fenced and the agent returns success. Failure to receive a valid
+message from the failed node in the given timeout period results in
+fencing failure.</longdesc>
 <vendor-url>http://www.kernel.org/pub/linux/utils/kernel/kexec/</vendor-url>
 <parameters>
 	<parameter name="nodename" unique="0" required="0">
-		<getopt mixed="-n, --nodename" />
+		<getopt mixed="-n, --nodename=NODE" />
 		<content type="string" />
-		<shortdesc lang="en">Name or IP address of node to be fenced</shortdesc>
+		<shortdesc lang="en">Name or IP address of node to be fenced. This option is required for
+the "off" action.</shortdesc>
 	</parameter>
 	<parameter name="ipport" unique="0" required="0">
-		<getopt mixed="-p, --ipport" />
+		<getopt mixed="-p, --ipport=PORT" />
 		<content type="string" default="7410" />
-		<shortdesc lang="en">Port number</shortdesc>
+		<shortdesc lang="en">IP port number that the fence_kdump agent will use to listen for
+messages.</shortdesc>
 	</parameter>
 	<parameter name="family" unique="0" required="0">
-		<getopt mixed="-f, --family" />
+		<getopt mixed="-f, --family=FAMILY" />
 		<content type="string" default="auto" />
-		<shortdesc lang="en">Network family</shortdesc>
+		<shortdesc lang="en">IP network family. Force the fence_kdump agent to use a specific
+family. The value for FAMILY can be "auto", "ipv4", or
+"ipv6".</shortdesc>
 	</parameter>
 	<parameter name="action" unique="0" required="0">
-		<getopt mixed="-o, --action" />
+		<getopt mixed="-o, --action=ACTION" />
 		<content type="string" default="off" />
-		<shortdesc lang="en">Fencing action</shortdesc>
+		<shortdesc lang="en">Fencing action to perform. The value for ACTION can be either
+"off" or "metadata".</shortdesc>
 	</parameter>
 	<parameter name="timeout" unique="0" required="0">
-		<getopt mixed="-t, --timeout" />
+		<getopt mixed="-t, --timeout=TIMEOUT" />
 		<content type="string" default="60" />
-		<shortdesc lang="en">Timeout in seconds</shortdesc>
-	</parameter>
-	<parameter name="quiet" unique="0" required="0">
-		<getopt mixed="-q, --quiet" />
-		<content type="boolean"  />
-		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug-file or logging to syslog.</shortdesc>
+		<shortdesc lang="en">Number of seconds to wait for message from failed node. If no message
+is received within TIMEOUT seconds, the fence_kdump agent
+returns failure.</shortdesc>
 	</parameter>
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
@@ -53,5 +70,6 @@
 	<action name="off" />
 	<action name="monitor" />
 	<action name="metadata" />
+	<action name="validate-all" />
 </actions>
 </resource-agent>

--- a/tests/data/metadata/fence_vmware.xml
+++ b/tests/data/metadata/fence_vmware.xml
@@ -6,7 +6,7 @@ Before you can use this agent, it must be installed VI Perl Toolkit or vmrun com
 
 VI Perl Toolkit is preferred for VMware ESX/ESXi and Virtual Center. Vmrun command is only solution for VMware Server 1/2 (this command will works against ESX/ESXi 3.5 up2 and VC up2 too, but not cluster aware!) and is available as part of VMware VIX API SDK package. VI Perl and VIX API SDK are both available from VMware web pages (not int RHEL repository!). 
 
-You can specify type of VMware you are connecting to with \fB-d\fP switch (or \fIvmware_type\fR for stdin). Possible values are esx, server2 and server1.Default value is esx, which will use VI Perl. With server1 and server2, vmrun command is used.
+You can specify type of VMware you are connecting to with -d switch (or vmware_type for stdin). Possible values are esx, server2 and server1.Default value is esx, which will use VI Perl. With server1 and server2, vmrun command is used.
 
 After you have successfully installed VI Perl Toolkit or VIX API, you should be able to run fence_vmware_helper (part of this agent) or vmrun command. This agent supports only vmrun from version 2.0.0 (VIX API 1.6.0).</longdesc>
 <vendor-url>http://www.vmware.com</vendor-url>


### PR DESCRIPTION
This is done to improve readability of text when reading it from output of '-o metadata' like 'pcs' does for only 2 agents where these formatting string were found.

~~~
$ sed -i "s:\\\\\\\\f[IPRB]:':g" ./agents/kdump/fence_kdump.c
$ sed -i "s:\\\\\\\\f[IPRB]:':g" ./agents/vmware/fence_vmware.py
~~~

Text that was defining command line arguments has no quotes, just removed formatting strings.

If anything else needs changing in here feel free to let me know. This should not affect functionality. This targets only documentation of the `fence_kdump` and `fence_vmware` fence agents.