### PR TITLE
fence_compute/fence_evacuate: fix argument parsing for region_name

### DIFF
--- a/agents/compute/fence_compute.py
+++ b/agents/compute/fence_compute.py
@@ -381,7 +381,7 @@ def define_new_opts():
 		"order": 1,
 	}
 	all_opt["region_name"] = {
-		"getopt" : "",
+		"getopt" : ":",
 		"longopt" : "region-name",
 		"help" : "--region-name=[region]         Region Name",
 		"required" : "0",

--- a/agents/evacuate/fence_evacuate.py
+++ b/agents/evacuate/fence_evacuate.py
@@ -318,7 +318,7 @@ def define_new_opts():
 		"order": 1,
 	}
 	all_opt["region_name"] = {
-		"getopt" : "",
+		"getopt" : ":",
 		"longopt" : "region-name",
 		"help" : "--region-name=[region]                 Region Name",
 		"required" : "0",

--- a/tests/data/metadata/fence_compute.xml
+++ b/tests/data/metadata/fence_compute.xml
@@ -55,7 +55,7 @@
 	</parameter>
 	<parameter name="region_name" unique="0" required="0">
 		<getopt mixed="--region-name=[region]" />
-		<content type="boolean" default=""  />
+		<content type="string" default=""  />
 		<shortdesc lang="en">Region Name</shortdesc>
 	</parameter>
 	<parameter name="tenant_name" unique="0" required="0">

--- a/tests/data/metadata/fence_evacuate.xml
+++ b/tests/data/metadata/fence_evacuate.xml
@@ -55,7 +55,7 @@
 	</parameter>
 	<parameter name="region_name" unique="0" required="0">
 		<getopt mixed="--region-name=[region]" />
-		<content type="boolean" default=""  />
+		<content type="string" default=""  />
 		<shortdesc lang="en">Region Name</shortdesc>
 	</parameter>
 	<parameter name="tenant_name" unique="0" required="0">


### PR DESCRIPTION
The region_name attribute for fence_compute and fence_evacuate is not a boolean
and should expect a string argument.