### PR TITLE
High: mpath: Correction of failure detection behavior from watchdog service.

### DIFF
--- a/agents/mpath/fence_mpath.py
+++ b/agents/mpath/fence_mpath.py
@@ -117,12 +117,14 @@ def get_reservation_key(options, dev):
 	match = re.search(r"\s+key\s*=\s*0x(\S+)\s+", out["out"], re.IGNORECASE)
 	return match.group(1) if match else None
 
-def get_registration_keys(options, dev):
+def get_registration_keys(options, dev, fail=True):
 	keys = []
 	cmd = options["--mpathpersist-path"] + " -i -k -d " + dev
 	out = run_cmd(options, cmd)
 	if out["err"]:
-		fail_usage("Cannot get registration keys")
+		fail_usage("Cannot get registration keys", fail)
+		if not fail:
+			return []
 	for line in out["out"].split("\n"):
 		match = re.search(r"\s+0x(\S+)\s*", line)
 		if match:
@@ -183,7 +185,7 @@ def mpath_check(hardreboot=False):
 		logging.error("No devices found")
 		return 0
 	for dev, key in list(devs.items()):
-		if key in get_registration_keys(options, dev):
+		if key in get_registration_keys(options, dev, fail=False):
 			logging.debug("key " + key + " registered with device " + dev)
 			return 0
 		else:


### PR DESCRIPTION
Hi All,

When fence_mpath is used together with watchdog service, restart by watchdog service is not executed after multipath disconnection.

The problem is that the next get_registration_keys(fail_usage) is exiting.

```
(snip)
def get_registration_keys(options, dev):
	keys = []
	cmd = options["--mpathpersist-path"] + " -i -k -d " + dev
	out = run_cmd(options, cmd)
	if out["err"]:
		fail_usage("Cannot get registration keys")
	for line in out["out"].split("\n"):
		match = re.search(r"\s+0x(\S+)\s*", line)
		if match:
			keys.append(match.group(1))
	return keys
(snip)
def mpath_check(hardreboot=False):
	if len(sys.argv) >= 3 and sys.argv[1] == "repair":
		return int(sys.argv[2])
	options = {}
	options["--mpathpersist-path"] = "/usr/sbin/mpathpersist"
	options["--store-path"] = "/var/run/cluster"
	options["--power-timeout"] = "5"
	if mpath_check_get_verbose():
		logging.getLogger().setLevel(logging.DEBUG)
	devs = dev_read(options, fail=False)
	if not devs:
		logging.error("No devices found")
		return 0
	for dev, key in list(devs.items()):
		if key in get_registration_keys(options, dev):
			logging.debug("key " + key + " registered with device " + dev)
(snip)
```

I fixed it so that it is processed correctly with reference to fence_scsi.

Best Regards,
Hideo Yamauchi.