### PR TITLE
Invert the force-down/service disable order

### DIFF
--- a/agents/compute/fence_compute.py
+++ b/agents/compute/fence_compute.py
@@ -117,11 +117,11 @@ def set_power_status_off(connection, options):
 	if status in [ "off" ]:
 		return
 
-	connection.services.disable(options["--plug"], 'nova-compute')
 	try:
 		# Until 2.53
 		connection.services.force_down(
 			options["--plug"], "nova-compute", force_down=True)
+		connection.services.disable(options["--plug"], 'nova-compute')
 	except Exception as e:
 		# Something went wrong when we tried to force the host down.
 		# That could come from either an incompatible API version


### PR DESCRIPTION
In OpenStack Train we first observed that IHA was not working via
https://bugzilla.redhat.com/show_bug.cgi?id=1760213

The reason for this is that nova has made the disabling of the compute
service depend on the compute node being up via:
https://review.opendev.org/#/c/654596/

By first calling force-down, the subsequence service-disable API
call won't wait for the reachability of the compute node any
longer and the whole operation has the same outcome.

Tested this on an OSP Train environment and we correctly
got Instance HA working again and we observed the VMs being
restarted on the available compute nodes.

While doing this change we also remove the code that
tries to fallback in case the force-down API is not available in
nova. We do this to simplify the code a bit, and we can do so
since that code landed upstream in Openstack Liberty (OSP8)
which has been unmaintained and EOLed for a long time now.

Co-Authored-By: Luca Miccini <lmiccini@redhat.com>