### PR TITLE
fence_rhevm: added cookie file management

### DIFF
--- a/agents/rhevm/fence_rhevm.py
+++ b/agents/rhevm/fence_rhevm.py
@@ -117,7 +117,12 @@ def send_command(opt, command, method="GET"):
 		conn.setopt(pycurl.HTTPAUTH, pycurl.HTTPAUTH_BASIC)
 		conn.setopt(pycurl.USERPWD, opt["--username"] + ":" + opt["--password"])
 		if "--use-cookies" in opt:
-			conn.setopt(pycurl.COOKIEFILE, "")
+			if "--cookie-file" in opt:
+				cookie_file = opt["--cookie-file"]
+			else:
+				cookie_file = "/tmp/fence_rhevm_" + opt["--ip"] + "_" + opt["--username"] + "_cookie.dat"
+			conn.setopt(pycurl.COOKIEFILE, cookie_file)
+			conn.setopt(pycurl.COOKIEJAR, cookie_file)
 
 	conn.setopt(pycurl.TIMEOUT, int(opt["--shell-timeout"]))
 	if "--ssl" in opt or "--ssl-secure" in opt:
@@ -166,6 +171,14 @@ def define_new_opts():
 		"required" : "0",
 		"shortdesc" : "Reuse cookies for authentication",
 		"order" : 1}
+	all_opt["cookie_file"] = {
+		"getopt" : ":",
+		"longopt" : "cookie-file",
+		"help" : "--cookie-file                  Path to cookie file for authentication\n"
+                        "\t\t\t\t  (Default: /tmp/fence_rhevm_ip_username_cookie.dat)",
+		"required" : "0",
+		"shortdesc" : "Path to cookie file for authentication",
+		"order" : 2}
 	all_opt["api_version"] = {
 		"getopt" : ":",
 		"longopt" : "api-version",

--- a/agents/rhevm/fence_rhevm.py
+++ b/agents/rhevm/fence_rhevm.py
@@ -4,6 +4,7 @@ import sys, re
 import pycurl, io
 import logging
 import atexit
+import tempfile
 sys.path.append("@FENCEAGENTSLIBDIR@")
 from fencing import *
 from fencing import fail, EC_FETCH_VM_UUID, run_delay
@@ -120,7 +121,7 @@ def send_command(opt, command, method="GET"):
 			if "--cookie-file" in opt:
 				cookie_file = opt["--cookie-file"]
 			else:
-				cookie_file = "/tmp/fence_rhevm_" + opt["--ip"] + "_" + opt["--username"] + "_cookie.dat"
+				cookie_file = tempfile.gettempdir() + "/fence_rhevm_" + opt["--ip"] + "_" + opt["--username"] + "_cookie.dat"
 			conn.setopt(pycurl.COOKIEFILE, cookie_file)
 			conn.setopt(pycurl.COOKIEJAR, cookie_file)
 
@@ -215,6 +216,7 @@ def main():
 		"web",
 		"port",
 		"use_cookies",
+		"cookie_file",
 		"api_version",
 		"api_path",
 		"disable_http_filter",

--- a/tests/data/metadata/fence_rhevm.xml
+++ b/tests/data/metadata/fence_rhevm.xml
@@ -103,6 +103,11 @@
 		<content type="string" default="auto"  />
 		<shortdesc lang="en">Version of RHEV API (default: auto)</shortdesc>
 	</parameter>
+	<parameter name="cookie_file" unique="0" required="0">
+		<getopt mixed="--cookie-file" />
+		<content type="string"  />
+		<shortdesc lang="en">Path to cookie file for authentication</shortdesc>
+	</parameter>
 	<parameter name="api_path" unique="0" required="0">
 		<getopt mixed="--api-path=[path]" />
 		<shortdesc lang="en">The path part of the API URL</shortdesc>


### PR DESCRIPTION
We are using fence_rhevm many places but it was annoyingly spamming the RHV manager event logs with a new login every time the agent run status or any other actions. Reuse cookie was handy in case another action happened during the same session.
The change introduce a new option, --cookie-file. It should be full path where the cookie file should be created. By default the name is generated from the IP+username and the file created under /tmp.
This way the agent will store the cookie and use the same session until it's available. In case of manager restart new session will be opened.
In case the cookie file is stored on clustered filesystem the session will be kept in case of cluster node restarts or resource move.