### PR TITLE
Fix shortopts in help messages for fence_compute and fence_evacuate 

### DIFF
--- a/agents/compute/fence_compute.py
+++ b/agents/compute/fence_compute.py
@@ -365,7 +365,7 @@ def define_new_opts():
 	all_opt["project-domain"] = {
 		"getopt" : "P:",
 		"longopt" : "project-domain",
-		"help" : "-d, --project-domain=[name]    Keystone v3 Project Domain",
+		"help" : "-P, --project-domain=[name]    Keystone v3 Project Domain",
 		"required" : "0",
 		"shortdesc" : "Keystone v3 Project Domain",
 		"default" : "Default",

--- a/agents/evacuate/fence_evacuate.py
+++ b/agents/evacuate/fence_evacuate.py
@@ -302,7 +302,7 @@ def define_new_opts():
 	all_opt["project-domain"] = {
 		"getopt" : "P:",
 		"longopt" : "project-domain",
-		"help" : "-d, --project-domain=[name]    Keystone v3 Project Domain",
+		"help" : "-P, --project-domain=[name]    Keystone v3 Project Domain",
 		"required" : "0",
 		"shortdesc" : "Keystone v3 Project Domain",
 		"default" : "Default",

--- a/tests/data/metadata/fence_compute.xml
+++ b/tests/data/metadata/fence_compute.xml
@@ -74,12 +74,12 @@
 		<shortdesc lang="en">Allow Insecure TLS Requests</shortdesc>
 	</parameter>
 	<parameter name="project-domain" unique="0" required="0" deprecated="1">
-		<getopt mixed="-d, --project-domain=[name]" />
+		<getopt mixed="-P, --project-domain=[name]" />
 		<content type="string" default="Default"  />
 		<shortdesc lang="en">Keystone v3 Project Domain</shortdesc>
 	</parameter>
 	<parameter name="project_domain" unique="0" required="0" obsoletes="project-domain">
-		<getopt mixed="-d, --project-domain=[name]" />
+		<getopt mixed="-P, --project-domain=[name]" />
 		<content type="string" default="Default"  />
 		<shortdesc lang="en">Keystone v3 Project Domain</shortdesc>
 	</parameter>

--- a/tests/data/metadata/fence_evacuate.xml
+++ b/tests/data/metadata/fence_evacuate.xml
@@ -74,12 +74,12 @@
 		<shortdesc lang="en">Allow Insecure TLS Requests</shortdesc>
 	</parameter>
 	<parameter name="project-domain" unique="0" required="0" deprecated="1">
-		<getopt mixed="-d, --project-domain=[name]" />
+		<getopt mixed="-P, --project-domain=[name]" />
 		<content type="string" default="Default"  />
 		<shortdesc lang="en">Keystone v3 Project Domain</shortdesc>
 	</parameter>
 	<parameter name="project_domain" unique="0" required="0" obsoletes="project-domain">
-		<getopt mixed="-d, --project-domain=[name]" />
+		<getopt mixed="-P, --project-domain=[name]" />
 		<content type="string" default="Default"  />
 		<shortdesc lang="en">Keystone v3 Project Domain</shortdesc>
 	</parameter>


### PR DESCRIPTION
The shortopts in fence_compute and fence_evacuate help messages are incorrect.

The current help is :
`-d, --project-domain=[name]    Keystone v3 Project Domain`

`-d` is the shortopt of domain parameter.

should be
`-P, --project-domain=[name]    Keystone v3 Project Domain`

Signed-off-by: Kumabuchi Kenji <k.kumabuchi+curvygrin@gmail.com>