### PR TITLE
fence_vbox/fence_virsh: fix prompt issue for status-based actions

### DIFF
--- a/agents/vbox/fence_vbox.py
+++ b/agents/vbox/fence_vbox.py
@@ -93,8 +93,8 @@ def main():
 
     all_opt["secure"]["default"] = "1"
 
-    all_opt["cmd_prompt"]["default"] = [r"\[EXPECT\]#\ "]
-    all_opt["ssh_options"]["default"] = "-t '/bin/bash -c \"" + r"PS1=\\[EXPECT\\]#\  " + "/bin/bash --noprofile --norc\"'"
+    all_opt["cmd_prompt"]["default"] = [r"\[EXPECT\]#"]
+    all_opt["ssh_options"]["default"] = "-t '/bin/bash -c \"" + r"PS1=\\[EXPECT\\]# " + "/bin/bash --noprofile --norc\"'"
 
     opt = process_input(device_opt)
 

--- a/agents/virsh/fence_virsh.py
+++ b/agents/virsh/fence_virsh.py
@@ -69,8 +69,8 @@ def main():
 	atexit.register(atexit_handler)
 
 	all_opt["secure"]["default"] = "1"
-	all_opt["cmd_prompt"]["default"] = [r"\[EXPECT\]#\ "]
-	all_opt["ssh_options"]["default"] = "-t '/bin/bash -c \"" + r"PS1=\\[EXPECT\\]#\  " + "/bin/bash --noprofile --norc\"'"
+	all_opt["cmd_prompt"]["default"] = [r"\[EXPECT\]#"]
+	all_opt["ssh_options"]["default"] = "-t '/bin/bash -c \"" + r"PS1=\\[EXPECT\\]# " + "/bin/bash --noprofile --norc\"'"
 
 	options = check_input(device_opt, process_input(device_opt))
 

--- a/tests/data/metadata/fence_vbox.xml
+++ b/tests/data/metadata/fence_vbox.xml
@@ -12,12 +12,12 @@ By default, vbox needs to log in as a user that is a member of the vboxusers gro
 	</parameter>
 	<parameter name="cmd_prompt" unique="0" required="0" deprecated="1">
 		<getopt mixed="-c, --command-prompt=[prompt]" />
-		<content type="string" default="[&apos;\\[EXPECT\\]#\\ &apos;]"  />
+		<content type="string" default="[&apos;\\[EXPECT\\]#&apos;]"  />
 		<shortdesc lang="en">Force Python regex for command prompt</shortdesc>
 	</parameter>
 	<parameter name="command_prompt" unique="0" required="0" obsoletes="cmd_prompt">
 		<getopt mixed="-c, --command-prompt=[prompt]" />
-		<content type="string" default="[&apos;\\[EXPECT\\]#\\ &apos;]"  />
+		<content type="string" default="[&apos;\\[EXPECT\\]#&apos;]"  />
 		<shortdesc lang="en">Force Python regex for command prompt</shortdesc>
 	</parameter>
 	<parameter name="identity_file" unique="0" required="0">
@@ -97,7 +97,7 @@ By default, vbox needs to log in as a user that is a member of the vboxusers gro
 	</parameter>
 	<parameter name="ssh_options" unique="0" required="0">
 		<getopt mixed="--ssh-options=[options]" />
-		<content type="string" default="-t &apos;/bin/bash -c &quot;PS1=\\[EXPECT\\]#\  /bin/bash --noprofile --norc&quot;&apos;"  />
+		<content type="string" default="-t &apos;/bin/bash -c &quot;PS1=\\[EXPECT\\]# /bin/bash --noprofile --norc&quot;&apos;"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
 	<parameter name="username" unique="0" required="1" obsoletes="login">

--- a/tests/data/metadata/fence_virsh.xml
+++ b/tests/data/metadata/fence_virsh.xml
@@ -12,12 +12,12 @@ By default, virsh needs root account to do properly work. So you must allow ssh 
 	</parameter>
 	<parameter name="cmd_prompt" unique="0" required="0" deprecated="1">
 		<getopt mixed="-c, --command-prompt=[prompt]" />
-		<content type="string" default="[&apos;\\[EXPECT\\]#\\ &apos;]"  />
+		<content type="string" default="[&apos;\\[EXPECT\\]#&apos;]"  />
 		<shortdesc lang="en">Force Python regex for command prompt</shortdesc>
 	</parameter>
 	<parameter name="command_prompt" unique="0" required="0" obsoletes="cmd_prompt">
 		<getopt mixed="-c, --command-prompt=[prompt]" />
-		<content type="string" default="[&apos;\\[EXPECT\\]#\\ &apos;]"  />
+		<content type="string" default="[&apos;\\[EXPECT\\]#&apos;]"  />
 		<shortdesc lang="en">Force Python regex for command prompt</shortdesc>
 	</parameter>
 	<parameter name="identity_file" unique="0" required="0">
@@ -97,7 +97,7 @@ By default, virsh needs root account to do properly work. So you must allow ssh 
 	</parameter>
 	<parameter name="ssh_options" unique="0" required="0">
 		<getopt mixed="--ssh-options=[options]" />
-		<content type="string" default="-t &apos;/bin/bash -c &quot;PS1=\\[EXPECT\\]#\  /bin/bash --noprofile --norc&quot;&apos;"  />
+		<content type="string" default="-t &apos;/bin/bash -c &quot;PS1=\\[EXPECT\\]# /bin/bash --noprofile --norc&quot;&apos;"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
 	<parameter name="username" unique="0" required="1" obsoletes="login">


### PR DESCRIPTION
The `status` action (and any other status-based actions, like `off`,
which checks the status beforehand) was broken - it always
returned OFF for all the virtual nodes, even for the running ones:
    
``` 
$ fence_vbox -o list-status -a 10.0.2.2 -l 520414 --host-os=macos -k .ssh/id_rsa
centos_1905.1_pod-c1,0872858e-132e-44bc-89fe-23f7608cadb0,off
centos_1905.1_cmu,f9172ad8-0700-4c65-9aac-304f60175f44,off
centos-7-1-1.x86_64_1572001960195_51877,d8e19439-3cc7-43fc-8fd4-16b8c673f8f4,off
centos_1905.1_pod-c2,5eef6fe9-de25-4891-8326-d440a633d6a9,off
$ fence_vbox -o status -a 10.0.2.2 -l 520414 --host-os=macos -k .ssh/id_rsa --plug centos_1905.1_pod-c2
Status: OFF 
$ fence_vbox -o off -a 10.0.2.2 -l 520414 --host-os=macos -k .ssh/id_rsa --plug centos_1905.1_pod-c2
Success: Already OFF 
``` 
    
The logs added to the get_outlets_status() function revealed, that
the `VBoxManage list runningvms` command did not return the list of
running nodes, instead, it would always return a special symbol:
    
``` 
$ ./fence_vbox -o list-status -a 10.0.2.2 -l 520414 --host-os=macos -k .ssh/id_rsa
['/Applications/VirtualBox.app/Contents/MacOS/VBoxManage list vms', '"centos-7-1-1.x86_64_1572001960195_51877" {d8e19439-3cc7-43fc-8fd4-16b8c673f8f4}', '"centos_1905.1_pod-c1" {0872858e-132e-44bc-89fe-23f7608cadb0}', '"centos_1905.1_pod-c2" {5eef6fe9-de25-4891-8326-d440a633d6a9}', '"centos_1905.1_cmu" {f9172ad8-0700-4c65-9aac-304f60175f44}']
['/Applications/VirtualBox.app/Contents/MacOS/VBoxManage list runningvms ', '\x1b[A']
centos_1905.1_pod-c1,0872858e-132e-44bc-89fe-23f7608cadb0,off
centos_1905.1_cmu,f9172ad8-0700-4c65-9aac-304f60175f44,off
centos-7-1-1.x86_64_1572001960195_51877,d8e19439-3cc7-43fc-8fd4-16b8c673f8f4,off
centos_1905.1_pod-c2,5eef6fe9-de25-4891-8326-d440a633d6a9,off
``` 
  
The problem was fixed by removing the trailing space from the PS1 
bash prompt.
