### PR TITLE
spec: fix openstack BuildRequires for distros without Python 3

### DIFF
--- a/fence-agents.spec.in
+++ b/fence-agents.spec.in
@@ -134,7 +134,7 @@ BuildRequires: python-google-api-client python-boto3
 %endif
 # (-openstack)
 %ifarch x86_64 ppc64le
-BuildRequires: python3-novaclient python3-keystoneclient
+BuildRequires: python-novaclient python-keystoneclient
 %endif
 %endif
 


### PR DESCRIPTION
Fixes python 2 BRs from https://github.com/ClusterLabs/fence-agents/pull/305.