### PR TITLE
fence_redfish/fence_vmware_soap: suppress warnings correctly with new python-requests

### DIFF
--- a/agents/redfish/fence_redfish.py
+++ b/agents/redfish/fence_redfish.py
@@ -12,7 +12,6 @@ import requests
 import atexit
 sys.path.append("@FENCEAGENTSLIBDIR@")
 
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from fencing import *
 from fencing import fail_usage, run_delay
 
@@ -143,7 +142,8 @@ access to control power on a server."
 
     # Disable insecure-certificate-warning message
     if "--ssl-insecure" in opt:
-        requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+        import urllib3
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     # backwards compatibility for <ip>:<port>
     if options["--ip"].count(":") == 1:

--- a/agents/vmware_soap/fence_vmware_soap.py
+++ b/agents/vmware_soap/fence_vmware_soap.py
@@ -37,10 +37,10 @@ def soap_login(options):
 	if "--ssl" in options or "--ssl-secure" in options or "--ssl-insecure" in options:
 		if "--ssl-insecure" in options:
 			import ssl
-			from requests.packages.urllib3.exceptions import InsecureRequestWarning
+			import urllib3
 			if hasattr(ssl, '_create_unverified_context'):
 				ssl._create_default_https_context = ssl._create_unverified_context
-			requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+			urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 			verify = False
 		else:
 			verify = True


### PR DESCRIPTION
python-requests doesnt suppress warnings anymore, so it needs to be done in urllib3: https://stackoverflow.com/questions/27981545/suppress-insecurerequestwarning-unverified-https-request-is-being-made-in-pytho/28002687#28002687