### PR TITLE
Adjusting Typo on nova api parameter

### DIFF
--- a/agents/compute/fence_compute.py
+++ b/agents/compute/fence_compute.py
@@ -424,12 +424,12 @@ def define_new_opts():
 		"default" : "True",
 		"order": 5,
 	}
-	all_opt["no_shared_storage"] = {
+	all_opt["on_shared_storage"] = {
 		"getopt" : "",
-		"longopt" : "no-shared-storage",
-		"help" : "--no-shared-storage            Disable functionality for shared storage",
+		"longopt" : "on-shared-storage",
+		"help" : "--on-shared-storage            Enable functionality for shared storage",
 		"required" : "0",
-		"shortdesc" : "Disable functionality for dealing with shared storage",
+		"shortdesc" : "Enable functionality for dealing with shared storage",
 		"default" : "False",
 		"order": 5,
 	}
@@ -460,7 +460,7 @@ def main():
 
 	device_opt = ["login", "passwd", "tenant_name", "auth_url", "fabric_fencing", "no_login",
 			"no_password", "port", "domain", "compute-domain", "project-domain",
-			"user-domain", "no_shared_storage", "endpoint_type", "record_only",
+			"user-domain", "on_shared_storage", "endpoint_type", "record_only",
 			"instance_filtering", "insecure", "region_name"]
 	define_new_opts()
 	all_opt["shell_timeout"]["default"] = "180"


### PR DESCRIPTION
For nova evacuation, 
there is only one option for shared storage,  --on-shared-storage
current para meter of no_shared_storage needs to be updated or corrected to on_shared_storage

https://docs.openstack.org/nova/queens/admin/evacuate.html
https://docs.openstack.org/python-novaclient/latest/cli/nova.html#nova-evacuate
..
usage: nova evacuate [--password <password>] [--on-shared-storage] [--force] <server> [<host>]
..