### PR TITLE
fence_aws: Fix fence race, logging improvement and new debug option

### DIFF
--- a/agents/aws/fence_aws.py
+++ b/agents/aws/fence_aws.py
@@ -121,7 +121,7 @@ def define_new_opts():
 	all_opt["boto3_debug"] = {
 		"getopt" : "b:",
 		"longopt" : "boto3_debug",
-		"help" : "-b, --boto3_debug=on|off      Boto3 and Botocore library debug logging",
+		"help" : "-b, --boto3_debug=[on|off]      Boto3 and Botocore library debug logging",
 		"shortdesc": "Boto Lib debug",
 		"required": "0",
 		"order": 5

--- a/agents/aws/fence_aws.py
+++ b/agents/aws/fence_aws.py
@@ -121,7 +121,7 @@ def define_new_opts():
 	all_opt["boto3_debug"] = {
 		"getopt" : "b:",
 		"longopt" : "boto3_debug",
-		"help" : "-b, --boto3_debug=[on|off]      Boto3 and Botocore library debug logging",
+		"help" : "-b, --boto3_debug=[option]      Boto3 and Botocore library debug logging",
 		"shortdesc": "Boto Lib debug",
 		"required": "0",
 		"order": 5

--- a/agents/aws/fence_aws.py
+++ b/agents/aws/fence_aws.py
@@ -197,5 +197,4 @@ For instructions see: https://boto3.readthedocs.io/en/latest/guide/quickstart.ht
 	sys.exit(result)
 
 if __name__ == "__main__":
-
 	main()

--- a/agents/aws/fence_aws.py
+++ b/agents/aws/fence_aws.py
@@ -60,7 +60,7 @@ def get_power_status(conn, options):
 		logging.error("Failed to get power status: %s", e)
 		fail(EC_STATUS)
 
-def get_self_power_status(conn, options):
+def get_self_power_status(conn, instance_id):
 	try:
 		instance = conn.instances.filter(Filters=[{"Name": "instance-id", "Values": [instance_id]}])
 		state = list(instance)[0].state["Name"]
@@ -82,7 +82,7 @@ def set_power_status(conn, options):
 	my_instance = get_instance_id()
 	try:
 		if (options["--action"]=="off"):
-			if (get_self_power_status(conn,myinstance) == "ok"):
+			if (get_self_power_status(conn,my_instance) == "ok"):
 				conn.instances.filter(InstanceIds=[options["--plug"]]).stop(Force=True)
 				logger.info("Called StopInstance API call for %s", options["--plug"])
 			else:
@@ -196,7 +196,7 @@ if __name__ == "__main__":
 	logger.propagate = False
 	logger.setLevel(logging.INFO)
 	logger.addHandler(SyslogLibHandler())
-	logger.getLogger('botocore.vendored').propagate = False
+	logging.getLogger('botocore.vendored').propagate = False
 	
 
 	main()

--- a/agents/aws/fence_aws.py
+++ b/agents/aws/fence_aws.py
@@ -11,6 +11,12 @@ from fencing import fail, fail_usage, run_delay, EC_STATUS, SyslogLibHandler
 import boto3
 from botocore.exceptions import ClientError, EndpointConnectionError, NoRegionError
 
+logger = logging.getLogger("fence_aws")
+logger.propagate = False
+logger.setLevel(logging.INFO)
+logger.addHandler(SyslogLibHandler())
+logging.getLogger('botocore.vendored').propagate = False
+	
 def get_instance_id():
 	try:
 		r = requests.get('http://169.254.169.254/latest/meta-data/instance-id')
@@ -191,12 +197,5 @@ For instructions see: https://boto3.readthedocs.io/en/latest/guide/quickstart.ht
 	sys.exit(result)
 
 if __name__ == "__main__":
-
-	logger = logging.getLogger("fence_aws")
-	logger.propagate = False
-	logger.setLevel(logging.INFO)
-	logger.addHandler(SyslogLibHandler())
-	logging.getLogger('botocore.vendored').propagate = False
-	
 
 	main()

--- a/tests/data/metadata/fence_aws.xml
+++ b/tests/data/metadata/fence_aws.xml
@@ -36,6 +36,11 @@ For instructions see: https://boto3.readthedocs.io/en/latest/guide/quickstart.ht
 		<content type="string"  />
 		<shortdesc lang="en">Secret Key.</shortdesc>
 	</parameter>
+	<parameter name="boto3_debug" unique="0" required="0">
+		<getopt mixed="-b, --boto3_debug=[option]" />
+		<content type="string" default="off"  />
+		<shortdesc lang="en">Boto Lib debug</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />


### PR DESCRIPTION
Hello,

This PR has the objective to improve overall fence_aws functionality aligned with customer and field feedback.

###  What is Changing?

- **Fix fence Race condition**
Added a function called ```get_self_power_status()``` in which the instance executing the fence action will check its own status before fencing the other node. If the local EC2 instance's status is not "Running" it will not try to fence the other node as the local node has been already fenced. With the addition of this feature ```pcmk_delay_max``` and/or ```pcmk_delay_base``` can now be used and are encouraged to be used with fence_aws.

- **Logging Changes**
Stopped using parent "logging" from lib fencing.py and added its own local logger. The reason for this is to 1) avoid logs from being streamed to _stderr_; and 2) avoid hitting [RHBZ #1549366](https://bugzilla.redhat.com/show_bug.cgi?id=1549366) when `verbose` logging is enabled.
Also, now while using `verbose` option it will create `/var/log/fence_aws_debug.log` as by default on some distributions (Red Hat) rsyslogd isn't configured to stream `*.debug` messages to syslog. Also with `verbose` option enabled boto3 library will no longer get into debug mode to avoid its logging from flooding the log file (see next item for detail).

- **New Boto3 debug option**
Added a new option to enable Boto3 debug (**--boto3_debug**) which by default is set to "off". Once enabled it will create `/var/log/fence_aws_boto3.log` with all boto3 and AWS APIs debugging information. This is important as previously STONITH `verbose` option was being too noisy and capturing unnecessary information.

