### PR TITLE
build: add directory dependencies to avoid edge-case where generating

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,10 @@ ACLOCAL_AMFLAGS		= -I m4
 
 SUBDIRS			= lib agents doc
 
+agents: lib
+
+doc: agents
+
 install-exec-local:
 			$(INSTALL) -d $(DESTDIR)/$(LOGDIR)
 			$(INSTALL) -d $(DESTDIR)/$(CLUSTERVARRUN)


### PR DESCRIPTION
manpages could happen before fencing.py was generated