### PR TITLE
fence_openstack: import novaclient and keystone only when needed

### DIFF
--- a/agents/openstack/fence_openstack.py
+++ b/agents/openstack/fence_openstack.py
@@ -10,20 +10,6 @@ sys.path.append("/usr/share/fence")
 from fencing import *
 from fencing import fail_usage, is_executable, run_command, run_delay
 
-try:
-        from novaclient import client as novaclient
-        from keystoneauth1 import session as ksc_session
-        from keystoneauth1 import loading
-        legacy_import = False
-except ImportError:
-        try:
-                from novaclient import client as novaclient
-                from keystoneclient import session as ksc_session
-                from keystoneclient.auth.identity import v3
-                legacy_import = True
-        except ImportError:
-                pass
-
 def get_power_status(_, options):
         output = nova_run_command(options, "status")
         if (output == 'ACTIVE'):
@@ -36,6 +22,20 @@ def set_power_status(_, options):
     return
 
 def nova_login(username,password,projectname,auth_url,user_domain_name,project_domain_name):
+        try:
+                from novaclient import client as novaclient
+                from keystoneauth1 import session as ksc_session
+                from keystoneauth1 import loading
+                legacy_import = False
+        except ImportError:
+                try:
+                        from novaclient import client as novaclient
+                        from keystoneclient import session as ksc_session
+                        from keystoneclient.auth.identity import v3
+                        legacy_import = True
+                except ImportError:
+                        fail_usage("Failed: Nova not found or not accessible")
+
         if not legacy_import:
                 loader = loading.get_plugin_loader('password')
                 auth = loader.load_from_options(auth_url=auth_url,

--- a/configure.ac
+++ b/configure.ac
@@ -247,18 +247,6 @@ if echo "$AGENTS_LIST" | grep -q gce; then
 	fi
 fi
 
-if echo "$AGENTS_LIST" | grep -q openstack; then
-        AC_PYTHON_MODULE(novaclient)
-        AC_PYTHON_MODULE(keystoneauth1)
-        AC_PYTHON_MODULE(keystoneclient)
-        if test "x${HAVE_PYMOD_NOVACLIENT}" != xyes || \
-           (test "x${HAVE_PYMOD_KEYSTONEAUTH1}" != xyes || \
-           test "x${HAVE_PYMOD_KEYSTONECLIENT}" != xyes); then
-                AGENTS_LIST=$(echo "$AGENTS_LIST" | sed -E "s#openstack/fence_openstack.py( |$)##")
-                AC_MSG_WARN("Not building fence_openstack")
-        fi
-fi
-
 ## path to 3rd-party binaries
 AC_PATH_PROG([IPMITOOL_PATH], [ipmitool], [/usr/bin/ipmitool])
 AC_PATH_PROG([OPENSTACK_PATH], [openstack], [/usr/bin/openstack])


### PR DESCRIPTION
Remove build dependency and always allow printing of metadata
similar to fence_compute and fence_evacuate.