### PR TITLE
fence_ipmilan: Add ability to increase ipmitool verbosity

### DIFF
--- a/agents/ipmilan/fence_ipmilan.py
+++ b/agents/ipmilan/fence_ipmilan.py
@@ -92,6 +92,10 @@ def create_command(options, action):
 	# --action / -o
 	Cmd.append(" chassis power " + action)
 
+	# --verbose-level
+	if options["--verbose-level"] > 1:
+		Cmd.append(" -" + "v" * (options["--verbose-level"] - 1))
+
 	return (Cmd.cmd, Cmd.log)
 
 def define_new_opts():

--- a/tests/data/metadata/fence_aliyun.xml
+++ b/tests/data/metadata/fence_aliyun.xml
@@ -46,7 +46,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_alom.xml
+++ b/tests/data/metadata/fence_alom.xml
@@ -111,7 +111,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_amt.xml
+++ b/tests/data/metadata/fence_amt.xml
@@ -80,7 +80,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_amt_ws.xml
+++ b/tests/data/metadata/fence_amt_ws.xml
@@ -80,7 +80,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_apc.xml
+++ b/tests/data/metadata/fence_apc.xml
@@ -116,7 +116,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_apc_snmp.xml
+++ b/tests/data/metadata/fence_apc_snmp.xml
@@ -121,7 +121,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_aws.xml
+++ b/tests/data/metadata/fence_aws.xml
@@ -49,7 +49,12 @@ For instructions see: https://boto3.readthedocs.io/en/latest/guide/quickstart.ht
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_azure_arm.xml
+++ b/tests/data/metadata/fence_azure_arm.xml
@@ -106,7 +106,12 @@ When using network fencing the reboot-action will cause a quick-return once the 
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_bladecenter.xml
+++ b/tests/data/metadata/fence_bladecenter.xml
@@ -111,7 +111,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_brocade.xml
+++ b/tests/data/metadata/fence_brocade.xml
@@ -111,7 +111,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_cisco_mds.xml
+++ b/tests/data/metadata/fence_cisco_mds.xml
@@ -120,7 +120,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_cisco_ucs.xml
+++ b/tests/data/metadata/fence_cisco_ucs.xml
@@ -96,7 +96,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_compute.xml
+++ b/tests/data/metadata/fence_compute.xml
@@ -131,7 +131,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_docker.xml
+++ b/tests/data/metadata/fence_docker.xml
@@ -84,7 +84,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_drac.xml
+++ b/tests/data/metadata/fence_drac.xml
@@ -81,7 +81,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_drac5.xml
+++ b/tests/data/metadata/fence_drac5.xml
@@ -120,7 +120,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_dummy.xml
+++ b/tests/data/metadata/fence_dummy.xml
@@ -31,7 +31,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_eaton_snmp.xml
+++ b/tests/data/metadata/fence_eaton_snmp.xml
@@ -120,7 +120,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_emerson.xml
+++ b/tests/data/metadata/fence_emerson.xml
@@ -120,7 +120,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_eps.xml
+++ b/tests/data/metadata/fence_eps.xml
@@ -83,7 +83,12 @@ Agent basically works by connecting to hidden page and pass appropriate argument
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_evacuate.xml
+++ b/tests/data/metadata/fence_evacuate.xml
@@ -126,7 +126,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_gce.xml
+++ b/tests/data/metadata/fence_gce.xml
@@ -56,7 +56,12 @@ For instructions see: https://cloud.google.com/compute/docs/tutorials/python-gui
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_hds_cb.xml
+++ b/tests/data/metadata/fence_hds_cb.xml
@@ -111,7 +111,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_heuristics_ping.xml
+++ b/tests/data/metadata/fence_heuristics_ping.xml
@@ -56,7 +56,12 @@ This is not a fence agent by itself! Its only purpose is to enable/disable anoth
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_hpblade.xml
+++ b/tests/data/metadata/fence_hpblade.xml
@@ -111,7 +111,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ibmblade.xml
+++ b/tests/data/metadata/fence_ibmblade.xml
@@ -120,7 +120,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_idrac.xml
+++ b/tests/data/metadata/fence_idrac.xml
@@ -123,7 +123,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ifmib.xml
+++ b/tests/data/metadata/fence_ifmib.xml
@@ -122,7 +122,12 @@ It was written with managed ethernet switches in mind, in order to fence iSCSI S
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ilo.xml
+++ b/tests/data/metadata/fence_ilo.xml
@@ -107,7 +107,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ilo2.xml
+++ b/tests/data/metadata/fence_ilo2.xml
@@ -107,7 +107,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ilo3.xml
+++ b/tests/data/metadata/fence_ilo3.xml
@@ -123,7 +123,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ilo3_ssh.xml
+++ b/tests/data/metadata/fence_ilo3_ssh.xml
@@ -124,7 +124,12 @@ WARNING: The monitor-action is prone to timeouts. Use the fence_ilo-equivalent t
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ilo4.xml
+++ b/tests/data/metadata/fence_ilo4.xml
@@ -123,7 +123,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ilo4_ssh.xml
+++ b/tests/data/metadata/fence_ilo4_ssh.xml
@@ -124,7 +124,12 @@ WARNING: The monitor-action is prone to timeouts. Use the fence_ilo-equivalent t
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ilo5.xml
+++ b/tests/data/metadata/fence_ilo5.xml
@@ -123,7 +123,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ilo5_ssh.xml
+++ b/tests/data/metadata/fence_ilo5_ssh.xml
@@ -124,7 +124,12 @@ WARNING: The monitor-action is prone to timeouts. Use the fence_ilo-equivalent t
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ilo_moonshot.xml
+++ b/tests/data/metadata/fence_ilo_moonshot.xml
@@ -111,7 +111,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ilo_mp.xml
+++ b/tests/data/metadata/fence_ilo_mp.xml
@@ -111,7 +111,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ilo_ssh.xml
+++ b/tests/data/metadata/fence_ilo_ssh.xml
@@ -124,7 +124,12 @@ WARNING: The monitor-action is prone to timeouts. Use the fence_ilo-equivalent t
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_imm.xml
+++ b/tests/data/metadata/fence_imm.xml
@@ -123,7 +123,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_intelmodular.xml
+++ b/tests/data/metadata/fence_intelmodular.xml
@@ -122,7 +122,12 @@ Note: Since firmware update version 2.7, SNMP v2 write support is removed, and r
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ipdu.xml
+++ b/tests/data/metadata/fence_ipdu.xml
@@ -120,7 +120,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ipmilan.xml
+++ b/tests/data/metadata/fence_ipmilan.xml
@@ -123,7 +123,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ironic.xml
+++ b/tests/data/metadata/fence_ironic.xml
@@ -76,7 +76,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ldom.xml
+++ b/tests/data/metadata/fence_ldom.xml
@@ -113,7 +113,12 @@ Very useful parameter is -c (or cmd_prompt in stdin mode). This must be set to s
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_lpar.xml
+++ b/tests/data/metadata/fence_lpar.xml
@@ -125,7 +125,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_mpath.xml
+++ b/tests/data/metadata/fence_mpath.xml
@@ -37,7 +37,12 @@ The fence_mpath agent works by having a unique key for each node that has to be 
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_netio.xml
+++ b/tests/data/metadata/fence_netio.xml
@@ -71,7 +71,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_openstack.xml
+++ b/tests/data/metadata/fence_openstack.xml
@@ -101,7 +101,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_ovh.xml
+++ b/tests/data/metadata/fence_ovh.xml
@@ -61,7 +61,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_powerman.xml
+++ b/tests/data/metadata/fence_powerman.xml
@@ -41,7 +41,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_pve.xml
+++ b/tests/data/metadata/fence_pve.xml
@@ -94,7 +94,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_raritan.xml
+++ b/tests/data/metadata/fence_raritan.xml
@@ -71,7 +71,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_rcd_serial.xml
+++ b/tests/data/metadata/fence_rcd_serial.xml
@@ -29,7 +29,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_redfish.xml
+++ b/tests/data/metadata/fence_redfish.xml
@@ -106,7 +106,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_rhevm.xml
+++ b/tests/data/metadata/fence_rhevm.xml
@@ -115,7 +115,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_rsa.xml
+++ b/tests/data/metadata/fence_rsa.xml
@@ -111,7 +111,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_rsb.xml
+++ b/tests/data/metadata/fence_rsb.xml
@@ -111,7 +111,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_sanbox2.xml
+++ b/tests/data/metadata/fence_sanbox2.xml
@@ -81,7 +81,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_sbd.xml
+++ b/tests/data/metadata/fence_sbd.xml
@@ -39,7 +39,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_scsi.xml
+++ b/tests/data/metadata/fence_scsi.xml
@@ -54,7 +54,12 @@ When used as a watchdog device you can define e.g. retry=1, retry-sleep=2 and ve
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_skalar.xml
+++ b/tests/data/metadata/fence_skalar.xml
@@ -96,7 +96,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_tripplite_snmp.xml
+++ b/tests/data/metadata/fence_tripplite_snmp.xml
@@ -121,7 +121,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_vbox.xml
+++ b/tests/data/metadata/fence_vbox.xml
@@ -113,7 +113,12 @@ By default, vbox needs to log in as a user that is a member of the vboxusers gro
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_virsh.xml
+++ b/tests/data/metadata/fence_virsh.xml
@@ -113,7 +113,12 @@ By default, virsh needs root account to do properly work. So you must allow ssh 
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_vmware.xml
+++ b/tests/data/metadata/fence_vmware.xml
@@ -124,7 +124,12 @@ After you have successfully installed VI Perl Toolkit or VIX API, you should be 
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_vmware_rest.xml
+++ b/tests/data/metadata/fence_vmware_rest.xml
@@ -102,7 +102,12 @@ NOTE: If there's more than 1000 VMs there is a filter parameter to work around t
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_vmware_soap.xml
+++ b/tests/data/metadata/fence_vmware_soap.xml
@@ -93,7 +93,12 @@ Name of virtual machine (-n / port) has to be used in inventory path format (e.g
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_vmware_vcloud.xml
+++ b/tests/data/metadata/fence_vmware_vcloud.xml
@@ -95,7 +95,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_wti.xml
+++ b/tests/data/metadata/fence_wti.xml
@@ -111,7 +111,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_xenapi.xml
+++ b/tests/data/metadata/fence_xenapi.xml
@@ -61,7 +61,12 @@
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />

--- a/tests/data/metadata/fence_zvmip.xml
+++ b/tests/data/metadata/fence_zvmip.xml
@@ -104,7 +104,12 @@ to access the system's directory manager.
 	<parameter name="verbose" unique="0" required="0">
 		<getopt mixed="-v, --verbose" />
 		<content type="boolean"  />
-		<shortdesc lang="en">Verbose mode</shortdesc>
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
 	</parameter>
 	<parameter name="debug" unique="0" required="0" deprecated="1">
 		<getopt mixed="-D, --debug-file=[debugfile]" />


### PR DESCRIPTION
Currently, the `-v` flag only causes the `ipmitool` command line and
output to be printed.

This patch allows `fence_ipmilan` to accept additional `-v` flags and
pass them on to `ipmitool` to get more verbosity.

Depends on: #346 
Related to: RHBZ#1853973