### PR TITLE
Make sure fence-compute depends on novaclient

### DIFF
--- a/fence-agents.spec.in
+++ b/fence-agents.spec.in
@@ -398,8 +398,10 @@ License: GPLv2+ and LGPLv2+
 Summary: Fence agent for Nova compute nodes
 %if 0%{?fedora} || 0%{?centos} > 7 || 0%{?rhel} > 7 || 0%{?suse_version}
 Requires: python3-requests
+Requires: python3-novaclient
 %else
 Requires: python-requests
+Requires: python2-novaclient
 %endif
 Requires: fence-agents-common = %{version}-%{release}
 BuildArch: noarch


### PR DESCRIPTION
fence-compute depends on novaclient to work, so this commit adds
the explicit dependency to make sure the necessary rpm is
installed along the fence-agent.