### PR TITLE
[fence_evacuate] Enable evacuation of instances using private flavors

### DIFF
--- a/agents/evacuate/fence_evacuate.py
+++ b/agents/evacuate/fence_evacuate.py
@@ -87,7 +87,7 @@ def _is_server_evacuable(server, evac_flavors, evac_images):
 
 def _get_evacuable_flavors(connection):
 	result = []
-	flavors = connection.flavors.list()
+	flavors = connection.flavors.list(is_public=None)
 	# Since the detailed view for all flavors doesn't provide the extra specs,
 	# we need to call each of the flavor to get them.
 	for flavor in flavors:


### PR DESCRIPTION
This commit extends the flavor.list() api call to fetch private
flavors that could be tagged with the 'evacuable' attribute,
essentially allowing instance-ha to be enabled on a per tenant basis.