### PR TITLE
 fence_lpar: Fix list-status action

### DIFF
--- a/agents/lpar/fence_lpar.py
+++ b/agents/lpar/fence_lpar.py
@@ -16,6 +16,16 @@ sys.path.append("@FENCEAGENTSLIBDIR@")
 from fencing import *
 from fencing import fail, fail_usage, EC_STATUS_HMC
 
+##
+## Transformation to standard ON/OFF status if possible
+def _normalize_status(status):
+	if status in ["Running", "Open Firmware", "Shutting Down", "Starting"]:
+		status = "on"
+	else:
+		status = "off"
+
+	return status
+
 def get_power_status(conn, options):
 	if options["--hmc-version"] == "3":
 		conn.send("lssyscfg -r lpar -m " + options["--managed"] + " -n " + options["--plug"] + " -F name,state\n")
@@ -42,14 +52,7 @@ def get_power_status(conn, options):
 		except AttributeError:
 			fail(EC_STATUS_HMC)
 
-	##
-	## Transformation to standard ON/OFF status if possible
-	if status in ["Running", "Open Firmware", "Shutting Down", "Starting"]:
-		status = "on"
-	else:
-		status = "off"
-
-	return status
+	return _normalize_status(status)
 
 def set_power_status(conn, options):
 	if options["--hmc-version"] == "3":
@@ -111,10 +114,10 @@ def get_lpar_list(conn, options):
 		lines = res.group(1).split("\n")
 		for outlet_line in lines:
 			try:
-				(port, status) = outlet_line.split(":")
+				(port, status) = outlet_line.rstrip().split(":")
 			except ValueError:
 				fail_usage('Output does not match expected HMC version, try different one');
-			outlets[port] = ("", status)
+			outlets[port] = ("", _normalize_status(status))
 	elif options["--hmc-version"] == "IVM":
 		conn.send("lssyscfg -r lpar -m " + options["--managed"] +
 			" -F name,state\n")
@@ -133,10 +136,10 @@ def get_lpar_list(conn, options):
 		lines = res.group(1).split("\n")
 		for outlet_line in lines:
 			try:
-				(port, status) = outlet_line.split(",")
+				(port, status) = outlet_line.rstrip().split(",")
 			except ValueError:
 				fail_usage('Output does not match expected HMC version, try different one');
-			outlets[port] = ("", status)
+			outlets[port] = ("", _normalize_status(status))
 
 	return outlets
 


### PR DESCRIPTION
The `list-status` action prints "UNKNOWN" status for all LPARs when
`--hmc-version` is `"4"` or `"IVM"`.

Here we fix that by mapping the statuses returned by the HMC
(e.g., "Running") to the statuses that the fencing library expects
(e.g., "on").

We also refactor `get_lpar_list` to reduce code duplication.

Resolves: RHBZ#1861926