### PR TITLE
fence_kdump: accept message from multiple addresses (useful for RRP clusters)

### DIFF
--- a/agents/kdump/fence_kdump.c
+++ b/agents/kdump/fence_kdump.c
@@ -168,7 +168,7 @@ do_action_off (const fence_kdump_opts_t *opts)
     list_for_each_entry (check_node, &opts->nodes, list) {
         log_debug (0, "waiting for message from '%s'\n", check_node->addr);
 	if (node->info->ai_family != check_node->info->ai_family) {
-            log_error (1, "mixing IPv4 and IPv6 nodes is not supported\n");
+            log_error (0, "mixing IPv4 and IPv6 nodes is not supported\n");
             return (1);
 	}
     }
@@ -218,7 +218,7 @@ do_action_off (const fence_kdump_opts_t *opts)
                 }
             }
         }
-    log_debug (0, "discard message from '%s'\n", addr);
+    log_debug (1, "discard message from '%s'\n", addr);
 
     }
 

--- a/agents/kdump/fence_kdump.c
+++ b/agents/kdump/fence_kdump.c
@@ -82,39 +82,6 @@ trim (char *str)
 }
 
 static int
-read_message (const fence_kdump_node_t *node, void *msg, int len)
-{
-    int error;
-    char addr[NI_MAXHOST];
-    char port[NI_MAXSERV];
-    struct sockaddr_storage ss;
-    socklen_t size = sizeof (ss);
-
-    error = recvfrom (node->socket, msg, len, 0, (struct sockaddr *) &ss, &size);
-    if (error < 0) {
-        log_error (2, "recvfrom (%s)\n", strerror (errno));
-        goto out;
-    }
-
-    error = getnameinfo ((struct sockaddr *) &ss, size,
-                         addr, sizeof (addr),
-                         port, sizeof (port),
-                         NI_NUMERICHOST | NI_NUMERICSERV);
-    if (error != 0) {
-        log_error (2, "getnameinfo (%s)\n", gai_strerror (error));
-        goto out;
-    }
-
-    error = strcasecmp (node->addr, addr);
-    if (error != 0) {
-        log_debug (1, "discard message from '%s'\n", addr);
-    }
-
-out:
-    return (error);
-}
-
-static int
 do_action_monitor (void)
 {
     const char cmdline_path[] = "/proc/cmdline";
@@ -151,6 +118,12 @@ do_action_off (const fence_kdump_opts_t *opts)
     fence_kdump_msg_t msg;
     fence_kdump_node_t *node;
     struct timeval timeout;
+    struct addrinfo hints;
+    fence_kdump_node_t *check_node;
+    char addr[NI_MAXHOST];
+    char port[NI_MAXSERV];
+    struct sockaddr_storage ss;
+    socklen_t size = sizeof (ss);
 
     if (list_empty (&opts->nodes)) {
         return (1);
@@ -164,7 +137,37 @@ do_action_off (const fence_kdump_opts_t *opts)
     FD_ZERO (&rfds);
     FD_SET (node->socket, &rfds);
 
-    log_debug (0, "waiting for message from '%s'\n", node->addr);
+    // create listening socket
+    memset (&hints, 0, sizeof (hints));
+
+    hints.ai_family = opts->family;
+    hints.ai_socktype = SOCK_DGRAM;
+    hints.ai_protocol = IPPROTO_UDP;
+    hints.ai_flags = AI_NUMERICSERV;
+
+    hints.ai_family = node->info->ai_family;
+    hints.ai_flags |= AI_PASSIVE;
+
+    freeaddrinfo (node->info);
+
+    node->info = NULL;
+    error = getaddrinfo (NULL, node->port, &hints, &node->info);
+    if (error != 0) {
+        log_error (2, "getaddrinfo (%s)\n", gai_strerror (error));
+        free_node (node);
+        return (1);
+    }
+
+    error = bind (node->socket, node->info->ai_addr, node->info->ai_addrlen);
+    if (error != 0) {
+        log_error (2, "bind (%s)\n", strerror (errno));
+        free_node (node);
+        return (1);
+    }
+
+    list_for_each_entry (check_node, &opts->nodes, list) {
+        log_debug (0, "waiting for message from '%s'\n", check_node->addr);
+    }
 
     for (;;) {
         error = select (node->socket + 1, &rfds, NULL, NULL, &timeout);
@@ -177,7 +180,18 @@ do_action_off (const fence_kdump_opts_t *opts)
             break;
         }
 
-        if (read_message (node, &msg, sizeof (msg)) != 0) {
+        error = recvfrom (node->socket, &msg, sizeof (msg), 0, (struct sockaddr *) &ss, &size);
+        if (error < 0) {
+            log_error (2, "recvfrom (%s)\n", strerror (errno));
+            continue;
+        }
+
+        error = getnameinfo ((struct sockaddr *) &ss, size,
+                             addr, sizeof (addr),
+                             port, sizeof (port),
+                             NI_NUMERICHOST | NI_NUMERICSERV);
+        if (error != 0) {
+            log_error (2, "getnameinfo (%s)\n", gai_strerror (error));
             continue;
         }
 
@@ -186,14 +200,22 @@ do_action_off (const fence_kdump_opts_t *opts)
             continue;
         }
 
-        switch (msg.version) {
-        case FENCE_KDUMP_MSGV1:
-            log_debug (0, "received valid message from '%s'\n", node->addr);
-            return (0);
-        default:
-            log_debug (1, "invalid message version '0x%X'\n", msg.version);
-            continue;
+        // check if we have matched messages from any known node
+        list_for_each_entry (check_node, &opts->nodes, list) {
+            error = strcasecmp (check_node->addr, addr);
+            if (error == 0 ) {
+                switch (msg.version) {
+                case FENCE_KDUMP_MSGV1:
+                    log_debug (0, "received valid message from '%s'\n", addr);
+                    return (0);
+                default:
+                    log_debug (1, "invalid message version '0x%X'\n", msg.version);
+                    continue;
+                }
+            }
         }
+    log_debug (0, "message from '%s' didn't match any expected nodes\n", addr);
+
     }
 
     return (1);
@@ -220,18 +242,21 @@ do_action_metadata (const char *self)
                      "message is received from the failed node, the node is considered to be\n"
                      "fenced and the agent returns success. Failure to receive a valid\n"
                      "message from the failed node in the given timeout period results in\n"
-                     "fencing failure.");
+                     "fencing failure. When multiple node names/IP addresses are specified\n"
+                     "a single valid message is sufficient for success. This is useful when\n"
+                     "single node can send message via several different IP addresses.\n");
     fprintf (stdout, "</longdesc>\n");
     fprintf (stdout, "<vendor-url>http://www.kernel.org/pub/linux/utils/kernel/kexec/</vendor-url>\n");
 
     fprintf (stdout, "<parameters>\n");
 
     fprintf (stdout, "\t<parameter name=\"nodename\" unique=\"0\" required=\"0\">\n");
-    fprintf (stdout, "\t\t<getopt mixed=\"-n, --nodename=NODE\" />\n");
+    fprintf (stdout, "\t\t<getopt mixed=\"-n, --nodename=NODE[,NODE...]\" />\n");
     fprintf (stdout, "\t\t<content type=\"string\" />\n");
     fprintf (stdout, "\t\t<shortdesc lang=\"en\">%s</shortdesc>\n",
-             "Name or IP address of node to be fenced. This option is required for\n"
-             "the \"off\" action.");
+             "List of names or IP addresses of node to be fenced. This option is\n"
+	     "required for the \"off\" action. Multiple values separated by commas\n"
+	     "can be specified. All values must be of same IP network family." );
     fprintf (stdout, "\t</parameter>\n");
 
     fprintf (stdout, "\t<parameter name=\"ipport\" unique=\"0\" required=\"0\">\n");
@@ -311,7 +336,7 @@ print_usage (const char *self)
     fprintf (stdout, "Options:\n");
     fprintf (stdout, "\n");
     fprintf (stdout, "%s\n",
-             "  -n, --nodename=NODE          Name or IP address of node to be fenced");
+             "  -n, --nodename=NODE[,NODE...]List of names or IP addresses of node to be fenced");
     fprintf (stdout, "%s\n",
              "  -p, --ipport=PORT            IP port number (default: 7410)");
     fprintf (stdout, "%s\n",
@@ -373,31 +398,11 @@ get_options_node (fence_kdump_opts_t *opts)
         return (1);
     }
 
-    hints.ai_family = node->info->ai_family;
-    hints.ai_flags |= AI_PASSIVE;
-
-    freeaddrinfo (node->info);
-
-    node->info = NULL;
-    error = getaddrinfo (NULL, node->port, &hints, &node->info);
-    if (error != 0) {
-        log_error (2, "getaddrinfo (%s)\n", gai_strerror (error));
-        free_node (node);
-        return (1);
-    }
-
     node->socket = socket (node->info->ai_family,
                            node->info->ai_socktype,
                            node->info->ai_protocol);
     if (node->socket < 0) {
         log_error (2, "socket (%s)\n", strerror (errno));
-        free_node (node);
-        return (1);
-    }
-
-    error = bind (node->socket, node->info->ai_addr, node->info->ai_addrlen);
-    if (error != 0) {
-        log_error (2, "bind (%s)\n", strerror (errno));
         free_node (node);
         return (1);
     }
@@ -521,6 +526,11 @@ main (int argc, char **argv)
 {
     int error = 1;
     fence_kdump_opts_t opts;
+    char *ptr;
+    char node_list[2049];
+    char node_list_tmp[2049];
+    memset(node_list, '\0', 2049);
+    memset(node_list_tmp, '\0', 2049);
 
     init_options (&opts);
 
@@ -537,10 +547,23 @@ main (int argc, char **argv)
             log_error (0, "action 'off' requires nodename\n");
             exit (1);
         }
+
+    strncpy(node_list, opts.nodename, 2048); //make local copy of nodename on which we can safely iterate
+    strncpy(node_list_tmp, opts.nodename, 2048); //store for later use
+    // iterate through node_list
+    ptr = strtok(node_list, ",");
+    while (ptr != NULL) {
+        //
+	set_option_nodename (&opts, ptr); //overwrite nodename for next function
         if (get_options_node (&opts) != 0) {
             log_error (0, "failed to get node '%s'\n", opts.nodename);
             exit (1);
         }
+        //
+        ptr = strtok(NULL, ",");
+    }
+    //
+    set_option_nodename (&opts, node_list_tmp); //restore original node_list into nodename
     }
 
     if (verbose != 0) {

--- a/agents/kdump/fence_kdump.c
+++ b/agents/kdump/fence_kdump.c
@@ -167,6 +167,10 @@ do_action_off (const fence_kdump_opts_t *opts)
 
     list_for_each_entry (check_node, &opts->nodes, list) {
         log_debug (0, "waiting for message from '%s'\n", check_node->addr);
+	if (node->info->ai_family != check_node->info->ai_family) {
+            log_error (1, "mixing IPv4 and IPv6 nodes is not supported\n");
+            return (1);
+	}
     }
 
     for (;;) {

--- a/agents/kdump/fence_kdump.c
+++ b/agents/kdump/fence_kdump.c
@@ -531,6 +531,7 @@ main (int argc, char **argv)
     int error = 1;
     fence_kdump_opts_t opts;
     char *ptr;
+    char *node_list;
 
     init_options (&opts);
 
@@ -543,11 +544,11 @@ main (int argc, char **argv)
     openlog ("fence_kdump", LOG_CONS|LOG_PID, LOG_DAEMON);
 
     if (opts.action == FENCE_KDUMP_ACTION_OFF) {
-        char node_list[strlen(opts.nodename)];
         if (opts.nodename == NULL) {
             log_error (0, "action 'off' requires nodename\n");
             exit (1);
         }
+        node_list = (char *)malloc(strlen(opts.nodename)+1);
 
         strcpy(node_list, opts.nodename); //make local copy of nodename on which we can safely iterate
         // iterate through node_list
@@ -558,6 +559,7 @@ main (int argc, char **argv)
                 exit (1);
             }
         }
+        free(node_list);
     }
 
     if (verbose != 0) {

--- a/agents/kdump/fence_kdump.c
+++ b/agents/kdump/fence_kdump.c
@@ -214,7 +214,7 @@ do_action_off (const fence_kdump_opts_t *opts)
                 }
             }
         }
-    log_debug (0, "message from '%s' didn't match any expected nodes\n", addr);
+    log_debug (0, "discard message from '%s'\n", addr);
 
     }
 
@@ -528,9 +528,7 @@ main (int argc, char **argv)
     fence_kdump_opts_t opts;
     char *ptr;
     char node_list[2049];
-    char node_list_tmp[2049];
     memset(node_list, '\0', 2049);
-    memset(node_list_tmp, '\0', 2049);
 
     init_options (&opts);
 
@@ -548,25 +546,23 @@ main (int argc, char **argv)
             exit (1);
         }
 
-    strncpy(node_list, opts.nodename, 2048); //make local copy of nodename on which we can safely iterate
-    strncpy(node_list_tmp, opts.nodename, 2048); //store for later use
-    // iterate through node_list
-    ptr = strtok(node_list, ",");
-    while (ptr != NULL) {
-        //
-	set_option_nodename (&opts, ptr); //overwrite nodename for next function
-        if (get_options_node (&opts) != 0) {
-            log_error (0, "failed to get node '%s'\n", opts.nodename);
-            exit (1);
+        strncpy(node_list, opts.nodename, 2048); //make local copy of nodename on which we can safely iterate
+        // iterate through node_list
+        ptr = strtok(node_list, ",");
+        while (ptr != NULL) {
+            set_option_nodename (&opts, ptr); //overwrite nodename for next function
+            if (get_options_node (&opts) != 0) {
+                log_error (0, "failed to get node '%s'\n", opts.nodename);
+                exit (1);
+            }
+            ptr = strtok(NULL, ",");
         }
-        //
-        ptr = strtok(NULL, ",");
-    }
-    //
-    set_option_nodename (&opts, node_list_tmp); //restore original node_list into nodename
     }
 
     if (verbose != 0) {
+        //clear nodename to avoid showing just last nodename here
+        free(opts.nodename);
+        opts.nodename = NULL;
         print_options (&opts);
     }
 

--- a/agents/kdump/fence_kdump.c
+++ b/agents/kdump/fence_kdump.c
@@ -530,9 +530,6 @@ main (int argc, char **argv)
 {
     int error = 1;
     fence_kdump_opts_t opts;
-    char *ptr;
-    char node_list[2049];
-    memset(node_list, '\0', 2049);
 
     init_options (&opts);
 
@@ -545,21 +542,20 @@ main (int argc, char **argv)
     openlog ("fence_kdump", LOG_CONS|LOG_PID, LOG_DAEMON);
 
     if (opts.action == FENCE_KDUMP_ACTION_OFF) {
+        char node_list[strlen(opts.nodename)];
         if (opts.nodename == NULL) {
             log_error (0, "action 'off' requires nodename\n");
             exit (1);
         }
 
-        strncpy(node_list, opts.nodename, 2048); //make local copy of nodename on which we can safely iterate
+        strcpy(node_list, opts.nodename); //make local copy of nodename on which we can safely iterate
         // iterate through node_list
-        ptr = strtok(node_list, ",");
-        while (ptr != NULL) {
+        for (char *ptr = strtok(node_list, ","); ptr != NULL; ptr = strtok(NULL, ",")) {
             set_option_nodename (&opts, ptr); //overwrite nodename for next function
             if (get_options_node (&opts) != 0) {
                 log_error (0, "failed to get node '%s'\n", opts.nodename);
                 exit (1);
             }
-            ptr = strtok(NULL, ",");
         }
     }
 

--- a/agents/kdump/fence_kdump.c
+++ b/agents/kdump/fence_kdump.c
@@ -530,6 +530,7 @@ main (int argc, char **argv)
 {
     int error = 1;
     fence_kdump_opts_t opts;
+    char *ptr;
 
     init_options (&opts);
 
@@ -550,7 +551,7 @@ main (int argc, char **argv)
 
         strcpy(node_list, opts.nodename); //make local copy of nodename on which we can safely iterate
         // iterate through node_list
-        for (char *ptr = strtok(node_list, ","); ptr != NULL; ptr = strtok(NULL, ",")) {
+        for (ptr = strtok(node_list, ","); ptr != NULL; ptr = strtok(NULL, ",")) {
             set_option_nodename (&opts, ptr); //overwrite nodename for next function
             if (get_options_node (&opts) != 0) {
                 log_error (0, "failed to get node '%s'\n", opts.nodename);

--- a/tests/data/metadata/fence_kdump.xml
+++ b/tests/data/metadata/fence_kdump.xml
@@ -15,14 +15,18 @@ acknowledges node has entered kdump crash recovery service. If a valid
 message is received from the failed node, the node is considered to be
 fenced and the agent returns success. Failure to receive a valid
 message from the failed node in the given timeout period results in
-fencing failure.</longdesc>
+fencing failure. When multiple node names/IP addresses are specified
+a single valid message is sufficient for success. This is useful when
+single node can send message via several different IP addresses.
+</longdesc>
 <vendor-url>http://www.kernel.org/pub/linux/utils/kernel/kexec/</vendor-url>
 <parameters>
 	<parameter name="nodename" unique="0" required="0">
-		<getopt mixed="-n, --nodename=NODE" />
+		<getopt mixed="-n, --nodename=NODE[,NODE...]" />
 		<content type="string" />
-		<shortdesc lang="en">Name or IP address of node to be fenced. This option is required for
-the "off" action.</shortdesc>
+		<shortdesc lang="en">List of names or IP addresses of node to be fenced. This option is
+required for the "off" action. Multiple values separated by commas
+can be specified. All values must be of same IP network family.</shortdesc>
 	</parameter>
 	<parameter name="ipport" unique="0" required="0">
 		<getopt mixed="-p, --ipport=PORT" />


### PR DESCRIPTION
Based on proposal (and feedback from @oalbrigt) in Issue https://github.com/ClusterLabs/fence-agents/issues/370 I have prepared and tested following code that adds support for `fence_kdump` to accepts both 'single node' and 'comma-separated list of nodes' from which valid message is accepted. This should improve fence_kdump ability to receive message from more than single IP which is typically possible in RRP clusters or clusters with several heartbeat links between nodes. Check the https://github.com/ClusterLabs/fence-agents/issues/370 for more detailed explanations.

Code proposed in this PR changes the behaviour of `fence_kdump` when comma-separated list of node is provided to `--nodename`/`-n` attribute. Using only one node as done so far will NOT cause any change in behaviour. There is a minor change in debug output when using `--verbose`/`-v` option where originally `nodename` was showing argument passed. With proposed change here this shows `(null)` which matches the output from `fence_kdump_send`.
Changes in code are inspired by `fence_kdump_send` that can send messages to multiple nodes at same time and therefore has structures for storing information about multiple nodes.

Limitations/notable changes in code:
- list of nodes must use same protocol family (either all hostnames/IPs are IPv4 or all are IPv6, no mixing)
- all nodes uses same port on which message can be received (there is no code that would parse ports for different nodes)
- `read_message` function code was inlined into `do_action_off` function which is only place where code is used
- it was quite long time since I have written any C code so there most probably is something that to trained eye will look ugly/wrong - help in this area is greatly appreciated

Please let me know if code in this form can be merged or what would need changing for this to be accepted. Thank you!

# testing outputs

## original fence_kdump

### IPv4
~~~
# fence_kdump -v -t 10 -n 10.0.0.78; echo $?
[debug]: options {
[debug]:     nodename = 10.0.0.78
[debug]:     ipport   = 7410
[debug]:     family   = 0
[debug]:     count    = 0
[debug]:     interval = 10
[debug]:     timeout  = 10
[debug]:     verbose  = 1
[debug]: }
[debug]: node {
[debug]:     name = 10.0.0.78
[debug]:     addr = 10.0.0.78
[debug]:     port = 7410
[debug]:     info = 0x55d2fbace420
[debug]: }
[debug]: waiting for message from '10.0.0.78'
[debug]: received valid message from '10.0.0.78'
0
~~~
~~~
# fence_kdump -t 10 -n 10.0.0.78; echo $?
[debug]: waiting for message from '10.0.0.78'
[debug]: received valid message from '10.0.0.78
0'
~~~
~~~
# fence_kdump -v -t 10 -n 10.0.0.99; echo $?
...
[debug]: waiting for message from '10.0.0.99'
[debug]: discard message from '10.0.0.78'
[debug]: discard message from '10.0.0.78'
[debug]: timeout after 10 seconds
1
~~~

### IPv6
~~~
# fence_kdump -v -t 10 -n 2002:beef::1; echo $?
[debug]: options {
[debug]:     nodename = 2002:beef::1
[debug]:     ipport   = 7410
[debug]:     family   = 0
[debug]:     count    = 0
[debug]:     interval = 10
[debug]:     timeout  = 10
[debug]:     verbose  = 1
[debug]: }
[debug]: node {
[debug]:     name = 2002:beef::1
[debug]:     addr = 2002:beef::1
[debug]:     port = 7410
[debug]:     info = 0x563151550420
[debug]: }
[debug]: waiting for message from '2002:beef::1'
[debug]: received valid message from '2002:beef::1'
0
~~~
~~~
# fence_kdump -t 10 -n 2002:beef::1; echo $?
[debug]: waiting for message from '2002:beef::1'
[debug]: received valid message from '2002:beef::1'
0
~~~
~~~
# fence_kdump -v -t 10 -n 2002:beef::3; echo $?
...
[debug]: waiting for message from '2002:beef::3'
[debug]: discard message from '2002:beef::1'
[debug]: discard message from '2002:beef::1'
[debug]: timeout after 10 seconds
1
~~~

### Unsupported scenarios
- multiple IPv4 addresses
~~~
# fence_kdump -n 10.0.0.78,192.168.2.78; echo $?
[error]: failed to get node '10.0.0.78,192.168.2.78'
1
~~~
- multiple IPv6 addresses
~~~
# fence_kdump -n 2002:beef::1,2002:deaf::1; echo $?
[error]: failed to get node '2002:beef::1,2002:deaf::1'
1
~~~
- mix of IPv4 and IPv6 addresses
~~~
# fence_kdump -n 2002:beef::1,192.168.2.78; echo $?
[error]: failed to get node '2002:beef::1,192.168.2.78'
1
~~~
=======

## Changed fence_kdump

### IPv4
~~~
# ./fence_kdump -v -t 10 -n 10.0.0.78; echo $?
[debug]: options {        
[debug]:     nodename = (null)
[debug]:     ipport   = 7410
[debug]:     family   = 0
[debug]:     count    = 0
[debug]:     interval = 10
[debug]:     timeout  = 10
[debug]:     verbose  = 1
[debug]: }                
[debug]: node {       
[debug]:     name = 10.0.0.78
[debug]:     addr = 10.0.0.78
[debug]:     port = 7410
[debug]:     info = 0x5579c21f4420
[debug]: }            
[debug]: waiting for message from '10.0.0.78'
[debug]: received valid message from '10.0.0.78'
0
~~~
~~~
# ./fence_kdump -t 10 -n 10.0.0.78; echo $?
[debug]: waiting for message from '10.0.0.78'
[debug]: received valid message from '10.0.0.78'
0
~~~
~~~
# ./fence_kdump -v -t 10 -n 10.0.0.99; echo $?
...
[debug]: waiting for message from '10.0.0.99'
[debug]: discard message from '10.0.0.78'
[debug]: discard message from '10.0.0.78'
[debug]: timeout after 10 seconds
1
~~~

### IPv6
~~~
# ./fence_kdump -v -t 10 -n 2002:beef::1; echo $?
[debug]: options {        
[debug]:     nodename = (null)
[debug]:     ipport   = 7410
[debug]:     family   = 0
[debug]:     count    = 0
[debug]:     interval = 10
[debug]:     timeout  = 10
[debug]:     verbose  = 1
[debug]: }                
[debug]: node {       
[debug]:     name = 2002:beef::1
[debug]:     addr = 2002:beef::1
[debug]:     port = 7410
[debug]:     info = 0x5560a10ff420
[debug]: }            
[debug]: waiting for message from '2002:beef::1'
[debug]: received valid message from '2002:beef::1'
0
~~~
~~~
# ./fence_kdump -t 10 -n 2002:beef::1; echo $?
[debug]: waiting for message from '2002:beef::1'
[debug]: received valid message from '2002:beef::1'
0
~~~
~~~
# ./fence_kdump -v -t 10 -n 2002:beef::3; echo $?
...
[debug]: waiting for message from '2002:beef::3'
[debug]: discard message from '2002:beef::1'
[debug]: discard message from '2002:beef::1'
[debug]: timeout after 10 seconds
1
~~~

### Newly supported scenarios
- multiple IPv4 addresses
~~~
# ./fence_kdump -n 10.0.0.78,192.168.2.78; echo $?
[debug]: waiting for message from '10.0.0.78'
[debug]: waiting for message from '192.168.2.78'
[debug]: received valid message from '10.0.0.78'
0
~~~
~~~
# ./fence_kdump -n 10.0.0.78,192.168.2.78; echo $?
[debug]: waiting for message from '10.0.0.78'
[debug]: waiting for message from '192.168.2.78'
[debug]: received valid message from '192.168.2.78'
0
~~~
- multiple IPv6 addresses
~~~
# ./fence_kdump -n 2002:beef::1,2002:deaf::1; echo $?
[debug]: waiting for message from '2002:beef::1'
[debug]: waiting for message from '2002:deaf::1'
[debug]: received valid message from '2002:beef::1'
0
~~~
~~~
# ./fence_kdump -n 2002:beef::1,2002:deaf::1; echo $?
[debug]: waiting for message from '2002:beef::1'
[debug]: waiting for message from '2002:deaf::1'
[debug]: received valid message from '2002:deaf::1'
0
~~~
### Unsupported scenarios
- mix of IPv4 and IPv6 addresses
~~~
# ./fence_kdump -n 2002:beef::1,192.168.2.78; echo $?
[debug]: waiting for message from '2002:beef::1'
[debug]: waiting for message from '192.168.2.78'
[error]: mixing IPv4 and IPv6 nodes is not supported
1
~~~
