### PR TITLE
fence_gce: default to onoff

### DIFF
--- a/agents/gce/fence_gce.py
+++ b/agents/gce/fence_gce.py
@@ -334,8 +334,6 @@ def main():
 	define_new_opts()
 
 	all_opt["power_timeout"]["default"] = "60"
-	all_opt["method"]["default"] = "cycle"
-	all_opt["method"]["help"] = "-m, --method=[method]          Method to fence (onoff|cycle) (Default: cycle)"
 
 	options = check_input(device_opt, process_input(device_opt))
 

--- a/tests/data/metadata/fence_gce.xml
+++ b/tests/data/metadata/fence_gce.xml
@@ -12,7 +12,7 @@ For instructions see: https://cloud.google.com/compute/docs/tutorials/python-gui
 	</parameter>
 	<parameter name="method" unique="0" required="0">
 		<getopt mixed="-m, --method=[method]" />
-		<content type="select" default="cycle"  >
+		<content type="select" default="onoff"  >
 			<option value="onoff" />
 			<option value="cycle" />
 		</content>


### PR DESCRIPTION
to avoid rejoining the cluster before the cycle action completes.