### PR TITLE
fence_vbox: do not flood host account (history) with vboxmanage calls

### DIFF
--- a/agents/vbox/fence_vbox.py
+++ b/agents/vbox/fence_vbox.py
@@ -94,7 +94,7 @@ def main():
     all_opt["secure"]["default"] = "1"
 
     all_opt["cmd_prompt"]["default"] = [r"\[EXPECT\]#"]
-    all_opt["ssh_options"]["default"] = "-t '/bin/bash -c \"" + r"PS1=\\[EXPECT\\]# " + "/bin/bash --noprofile --norc\"'"
+    all_opt["ssh_options"]["default"] = "-t '/bin/bash -c \"" + r"PS1=\\[EXPECT\\]# HISTFILE=/dev/null " + "/bin/bash --noprofile --norc\"'"
 
     opt = process_input(device_opt)
 

--- a/tests/data/metadata/fence_vbox.xml
+++ b/tests/data/metadata/fence_vbox.xml
@@ -97,7 +97,7 @@ By default, vbox needs to log in as a user that is a member of the vboxusers gro
 	</parameter>
 	<parameter name="ssh_options" unique="0" required="0">
 		<getopt mixed="--ssh-options=[options]" />
-		<content type="string" default="-t &apos;/bin/bash -c &quot;PS1=\\[EXPECT\\]# /bin/bash --noprofile --norc&quot;&apos;"  />
+		<content type="string" default="-t &apos;/bin/bash -c &quot;PS1=\\[EXPECT\\]# HISTFILE=/dev/null /bin/bash --noprofile --norc&quot;&apos;"  />
 		<shortdesc lang="en">SSH options to use</shortdesc>
 	</parameter>
 	<parameter name="username" unique="0" required="1" obsoletes="login">


### PR DESCRIPTION
This change disables bash history when checking vm status on host.
Useful mainly in devel installations, where fence_vbox.py fills user .bash_history with:

VBoxManage list vms
VBoxManage list runningvms

I think that there is no reason to log those commands in production environment, hence this pull request.

Tested on Centos7.8 and Virtualbox 6.1.16
