### PR TITLE
Add fence_ipmilanplus as fence_ipmilan wrapper always enabling lanplus

### DIFF
--- a/agents/ipmilan/fence_ipmilan.py
+++ b/agents/ipmilan/fence_ipmilan.py
@@ -187,6 +187,8 @@ def main():
 		all_opt["lanplus"]["default"] = "1"
 	elif os.path.basename(sys.argv[0]) == "fence_ilo5":
 		all_opt["lanplus"]["default"] = "1"
+	elif os.path.basename(sys.argv[0]) == "fence_ipmilanplus":
+		all_opt["lanplus"]["default"] = "1"
 
 	all_opt["ipport"]["default"] = "623"
 	all_opt["method"]["help"] = "-m, --method=[method]          Method to fence (onoff|cycle) (Default: onoff)\n" \
@@ -206,6 +208,7 @@ You should use -m/method onoff if your fence device works correctly with that op
 	docs["symlink"] = [("fence_ilo3", "Fence agent for HP iLO3"),
 		("fence_ilo4", "Fence agent for HP iLO4"),
 		("fence_ilo5", "Fence agent for HP iLO5"),
+		("fence_ipmilanplus", "Fence agent for IPMIv2 lanplus"),
 		("fence_imm", "Fence agent for IBM Integrated Management Module"),
 		("fence_idrac", "Fence agent for Dell iDRAC")]
 	show_docs(options, docs)

--- a/fence-agents.spec.in
+++ b/fence-agents.spec.in
@@ -758,6 +758,8 @@ Fence agents for devices with IPMI interface.
 %{_mandir}/man8/fence_ilo4.8*
 %{_sbindir}/fence_ilo5
 %{_mandir}/man8/fence_ilo5.8*
+%{_sbindir}/fence_ipmilanplus
+%{_mandir}/man8/fence_ipmilanplus.8*
 %{_sbindir}/fence_imm
 %{_mandir}/man8/fence_imm.8*
 

--- a/tests/data/metadata/fence_idrac.xml
+++ b/tests/data/metadata/fence_idrac.xml
@@ -3,6 +3,7 @@
 <symlink name="fence_ilo3" shortdesc="Fence agent for HP iLO3"/>
 <symlink name="fence_ilo4" shortdesc="Fence agent for HP iLO4"/>
 <symlink name="fence_ilo5" shortdesc="Fence agent for HP iLO5"/>
+<symlink name="fence_ipmilanplus" shortdesc="Fence agent for IPMIv2 lanplus"/>
 <symlink name="fence_imm" shortdesc="Fence agent for IBM Integrated Management Module"/>
 <symlink name="fence_idrac" shortdesc="Fence agent for Dell iDRAC"/>
 <longdesc>fence_ipmilan is an I/O Fencing agentwhich can be used with machines controlled by IPMI.This agent calls support software ipmitool (http://ipmitool.sf.net/). WARNING! This fence agent might report success before the node is powered off. You should use -m/method onoff if your fence device works correctly with that option.</longdesc>

--- a/tests/data/metadata/fence_ilo3.xml
+++ b/tests/data/metadata/fence_ilo3.xml
@@ -3,6 +3,7 @@
 <symlink name="fence_ilo3" shortdesc="Fence agent for HP iLO3"/>
 <symlink name="fence_ilo4" shortdesc="Fence agent for HP iLO4"/>
 <symlink name="fence_ilo5" shortdesc="Fence agent for HP iLO5"/>
+<symlink name="fence_ipmilanplus" shortdesc="Fence agent for IPMIv2 lanplus"/>
 <symlink name="fence_imm" shortdesc="Fence agent for IBM Integrated Management Module"/>
 <symlink name="fence_idrac" shortdesc="Fence agent for Dell iDRAC"/>
 <longdesc>fence_ipmilan is an I/O Fencing agentwhich can be used with machines controlled by IPMI.This agent calls support software ipmitool (http://ipmitool.sf.net/). WARNING! This fence agent might report success before the node is powered off. You should use -m/method onoff if your fence device works correctly with that option.</longdesc>

--- a/tests/data/metadata/fence_ilo4.xml
+++ b/tests/data/metadata/fence_ilo4.xml
@@ -3,6 +3,7 @@
 <symlink name="fence_ilo3" shortdesc="Fence agent for HP iLO3"/>
 <symlink name="fence_ilo4" shortdesc="Fence agent for HP iLO4"/>
 <symlink name="fence_ilo5" shortdesc="Fence agent for HP iLO5"/>
+<symlink name="fence_ipmilanplus" shortdesc="Fence agent for IPMIv2 lanplus"/>
 <symlink name="fence_imm" shortdesc="Fence agent for IBM Integrated Management Module"/>
 <symlink name="fence_idrac" shortdesc="Fence agent for Dell iDRAC"/>
 <longdesc>fence_ipmilan is an I/O Fencing agentwhich can be used with machines controlled by IPMI.This agent calls support software ipmitool (http://ipmitool.sf.net/). WARNING! This fence agent might report success before the node is powered off. You should use -m/method onoff if your fence device works correctly with that option.</longdesc>

--- a/tests/data/metadata/fence_ilo5.xml
+++ b/tests/data/metadata/fence_ilo5.xml
@@ -3,6 +3,7 @@
 <symlink name="fence_ilo3" shortdesc="Fence agent for HP iLO3"/>
 <symlink name="fence_ilo4" shortdesc="Fence agent for HP iLO4"/>
 <symlink name="fence_ilo5" shortdesc="Fence agent for HP iLO5"/>
+<symlink name="fence_ipmilanplus" shortdesc="Fence agent for IPMIv2 lanplus"/>
 <symlink name="fence_imm" shortdesc="Fence agent for IBM Integrated Management Module"/>
 <symlink name="fence_idrac" shortdesc="Fence agent for Dell iDRAC"/>
 <longdesc>fence_ipmilan is an I/O Fencing agentwhich can be used with machines controlled by IPMI.This agent calls support software ipmitool (http://ipmitool.sf.net/). WARNING! This fence agent might report success before the node is powered off. You should use -m/method onoff if your fence device works correctly with that option.</longdesc>

--- a/tests/data/metadata/fence_imm.xml
+++ b/tests/data/metadata/fence_imm.xml
@@ -3,6 +3,7 @@
 <symlink name="fence_ilo3" shortdesc="Fence agent for HP iLO3"/>
 <symlink name="fence_ilo4" shortdesc="Fence agent for HP iLO4"/>
 <symlink name="fence_ilo5" shortdesc="Fence agent for HP iLO5"/>
+<symlink name="fence_ipmilanplus" shortdesc="Fence agent for IPMIv2 lanplus"/>
 <symlink name="fence_imm" shortdesc="Fence agent for IBM Integrated Management Module"/>
 <symlink name="fence_idrac" shortdesc="Fence agent for Dell iDRAC"/>
 <longdesc>fence_ipmilan is an I/O Fencing agentwhich can be used with machines controlled by IPMI.This agent calls support software ipmitool (http://ipmitool.sf.net/). WARNING! This fence agent might report success before the node is powered off. You should use -m/method onoff if your fence device works correctly with that option.</longdesc>

--- a/tests/data/metadata/fence_ipmilanplus.xml
+++ b/tests/data/metadata/fence_ipmilanplus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<resource-agent name="fence_ipmilan" shortdesc="Fence agent for IPMI" >
+<resource-agent name="fence_ipmilanplus" shortdesc="Fence agent for IPMI" >
 <symlink name="fence_ilo3" shortdesc="Fence agent for HP iLO3"/>
 <symlink name="fence_ilo4" shortdesc="Fence agent for HP iLO4"/>
 <symlink name="fence_ilo5" shortdesc="Fence agent for HP iLO5"/>
@@ -50,7 +50,7 @@
 	</parameter>
 	<parameter name="lanplus" unique="0" required="0">
 		<getopt mixed="-P, --lanplus" />
-		<content type="boolean" default="0"  />
+		<content type="boolean" default="1"  />
 		<shortdesc lang="en">Use Lanplus to improve security of connection</shortdesc>
 	</parameter>
 	<parameter name="login" unique="0" required="0" deprecated="1">


### PR DESCRIPTION
Lanplus (IPMI protocol version 2) is the up-to-date protocol to
connect to all recent IPMI driven BMCs.
Using fence_ipmilan without lanplus=1 will fail on these.

To get around compatibility issues (old HW might still exist),
a new fence_agent is introduced via link and basename check.

This fixes #314.
