### PR TITLE
fence_gce: Adds cloud-platform scope for bare metal API and optional proxy flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
   - pip install oauth2client
   - pip install python-novaclient
   - pip install python-keystoneclient
-  - pip install PySocks
 
 before_script:
   - wget https://github.com/Openwsman/openwsman/archive/v2.6.3.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
   - pip install oauth2client
   - pip install python-novaclient
   - pip install python-keystoneclient
+  - pip install PySocks
 
 before_script:
   - wget https://github.com/Openwsman/openwsman/archive/v2.6.3.tar.gz

--- a/agents/gce/fence_gce.py
+++ b/agents/gce/fence_gce.py
@@ -15,7 +15,6 @@ import json
 import re
 import os
 import socket
-import socks
 import sys
 import time
 
@@ -34,6 +33,7 @@ try:
   import googleapiclient.discovery
   from oauth2client.client import GoogleCredentials
   from oauth2client.service_account import ServiceAccountCredentials
+  import socks
 except:
   pass
 

--- a/tests/data/metadata/fence_gce.xml
+++ b/tests/data/metadata/fence_gce.xml
@@ -73,6 +73,16 @@ For instructions see: https://cloud.google.com/compute/docs/tutorials/python-gui
 		<content type="string"  />
 		<shortdesc lang="en">Service Account to use for authentication to the google cloud APIs.</shortdesc>
 	</parameter>
+	<parameter name="proxyhost" unique="0" required="0">
+		<getopt mixed="--proxyhost=[proxy_host]" />
+		<content type="string"  />
+		<shortdesc lang="en">If a proxy is used for internet access, the proxy host should be specified.</shortdesc>
+	</parameter>
+	<parameter name="proxyport" unique="0" required="0">
+		<getopt mixed="--proxyport=[proxy_port]" />
+		<content type="integer"  />
+		<shortdesc lang="en">If a proxy is used for internet access, the proxy port should be specified.</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />


### PR DESCRIPTION
This change adds the necessary scope for using the fence agent on bare metal. Along with that we have added proxy flags in case the customer is using a proxy for internet access instead of a NAT gateway