### PR TITLE
spec: use python3 path for newer releases

### DIFF
--- a/fence-agents.spec.in
+++ b/fence-agents.spec.in
@@ -153,9 +153,9 @@ BuildRequires: python-novaclient python-keystoneclient
 sed -i.orig 's|FENCE_ZVM=1|FENCE_ZVM=0|' configure.ac
 
 %build
-if [ -z "$PYTHON " ]; then
+%if 0%{?fedora} || 0%{?centos} > 7 || 0%{?rhel} > 7 || 0%{?suse_version}
 	PYTHON="%{__python3}"
-fi
+%endif
 
 ./autogen.sh
 %{configure}


### PR DESCRIPTION
Fixes "make rpm" failing due to "ambiguous python shebang" when not
specifying PYTHON=.../python3.