### PR TITLE
Default method moved back to powercycle

### DIFF
--- a/agents/gce/fence_gce.py
+++ b/agents/gce/fence_gce.py
@@ -358,6 +358,8 @@ def main():
 	define_new_opts()
 
 	all_opt["power_timeout"]["default"] = "60"
+	all_opt["method"]["default"] = "cycle"
+	all_opt["method"]["help"] = "-m, --method=[method]          Method to fence (onoff|cycle) (Default: cycle)"
 
 	options = check_input(device_opt, process_input(device_opt))
 

--- a/tests/data/metadata/fence_gce.xml
+++ b/tests/data/metadata/fence_gce.xml
@@ -12,7 +12,7 @@ For instructions see: https://cloud.google.com/compute/docs/tutorials/python-gui
 	</parameter>
 	<parameter name="method" unique="0" required="0">
 		<getopt mixed="-m, --method=[method]" />
-		<content type="select" default="onoff"  >
+		<content type="select" default="cycle"  >
 			<option value="onoff" />
 			<option value="cycle" />
 		</content>


### PR DESCRIPTION
Moving back to powercycle as the default method for GCE.  This is the recommended approach from Google.  Using on/off as the default will have unintended consequences on google cloud platforms.