### PR TITLE
fence_openstack: Major rework of the original OpenStack agent.

### DIFF
--- a/agents/openstack/fence_openstack.py
+++ b/agents/openstack/fence_openstack.py
@@ -216,6 +216,7 @@ def define_new_opts():
 
 
 def main():
+    conn = None
 
     device_opt = [
         "login",
@@ -281,16 +282,19 @@ This agent calls the python-novaclient and it is mandatory to be installed "
     project_domain_name = options["--project-domain-name"]
     cacert = options["--cacert"]
     apitimeout = options["--apitimeout"]
-    conn = nova_login(
-        username,
-        password,
-        projectname,
-        auth_url,
-        user_domain_name,
-        project_domain_name,
-        cacert,
-        apitimeout,
-    )
+    try:
+        conn = nova_login(
+            username,
+            password,
+            projectname,
+            auth_url,
+            user_domain_name,
+            project_domain_name,
+            cacert,
+            apitimeout,
+        )
+    except Exception as e:
+        fail_usage("Failed: Unable to connect to Nova: " + str(e))
 
     # Operate the fencing device
     result = fence_action(conn, options, set_power_status, get_power_status, get_nodes_list)

--- a/agents/openstack/fence_openstack.py
+++ b/agents/openstack/fence_openstack.py
@@ -14,7 +14,7 @@ try:
     from novaclient import client
     from novaclient.exceptions import Conflict, NotFound
 except ImportError:
-    fail_usage("Failed: Nova client not found or not accessible")
+    pass
 
 urllib3.disable_warnings(urllib3.exceptions.SecurityWarning)
 

--- a/agents/openstack/fence_openstack.py
+++ b/agents/openstack/fence_openstack.py
@@ -2,151 +2,268 @@
 
 import atexit
 import logging
-import os
-import re
 import sys
-from pipes import quote
-sys.path.append("/usr/share/fence")
+
+import urllib3
+
+sys.path.append("@FENCEAGENTSLIBDIR@")
 from fencing import *
-from fencing import fail_usage, is_executable, run_command, run_delay
+from fencing import SyslogLibHandler, fail_usage, run_delay
 
-def get_power_status(_, options):
-        output = nova_run_command(options, "status")
-        if (output == 'ACTIVE'):
-                return 'on'
-        else:
-                return 'off'
+try:
+    from novaclient import client
+    from novaclient.exceptions import Conflict, NotFound
+except ImportError:
+    fail_usage("Failed: Nova client not found or not accessible")
 
-def set_power_status(_, options):
-    nova_run_command(options, options["--action"])
-    return
+urllib3.disable_warnings(urllib3.exceptions.SecurityWarning)
 
-def nova_login(username,password,projectname,auth_url,user_domain_name,project_domain_name):
+logger = logging.getLogger(__name__)
+logger.propagate = False
+logger.setLevel(logging.INFO)
+logger.addHandler(SyslogLibHandler())
+
+
+def translate_status(instance_status):
+    if instance_status == "ACTIVE":
+        return "on"
+    elif instance_status == "SHUTOFF":
+        return "off"
+    return "unknown"
+
+
+def get_nodes_list(conn, options):
+    logger.info("Running %s action", options["--action"])
+    result = {}
+    response = conn.servers.list(detailed=True)
+    if response is not None:
+        for item in response:
+            instance_id = item.id
+            instance_name = item.name
+            instance_status = item.status
+            result[instance_id] = (instance_name, translate_status(instance_status))
+    return result
+
+
+def get_power_status(conn, options):
+    logger.info("Running %s action on %s", options["--action"], options["--plug"])
+    server = None
+    try:
+        server = conn.servers.get(options["--plug"])
+    except NotFound as e:
+        fail_usage("Failed: Not Found: " + str(e))
+    if server is None:
+        fail_usage("Server %s not found", options["--plug"])
+    state = server.status
+    status = translate_status(state)
+    logger.info("get_power_status: %s (state: %s)" % (status, state))
+    return status
+
+
+def set_power_status(conn, options):
+    logger.info("Running %s action on %s", options["--action"], options["--plug"])
+    action = options["--action"]
+    server = None
+    try:
+        server = conn.servers.get(options["--plug"])
+    except NotFound as e:
+        fail_usage("Failed: Not Found: " + str(e))
+    if server is None:
+        fail_usage("Server %s not found", options["--plug"])
+    if action == "on":
+        logger.info("Starting instance " + server.name)
         try:
-                from novaclient import client as novaclient
-                from keystoneauth1 import session as ksc_session
-                from keystoneauth1 import loading
-                legacy_import = False
+            server.start()
+        except Conflict as e:
+            fail_usage(e)
+        logger.info("Called start API call for " + server.id)
+    if action == "off":
+        logger.info("Stopping instance " + server.name)
+        try:
+            server.stop()
+        except Conflict as e:
+            fail_usage(e)
+        logger.info("Called stop API call for " + server.id)
+    if action == "reboot":
+        logger.info("Rebooting instance " + server.name)
+        try:
+            server.reboot("HARD")
+        except Conflict as e:
+            fail_usage(e)
+        logger.info("Called reboot hard API call for " + server.id)
+
+
+def nova_login(
+    username,
+    password,
+    projectname,
+    auth_url,
+    user_domain_name,
+    project_domain_name,
+    cacert,
+    apitimeout,
+):
+    legacy_import = False
+
+    try:
+        from keystoneauth1 import loading
+        from keystoneauth1 import session as ksc_session
+        from keystoneauth1.exceptions.discovery import DiscoveryFailure
+        from keystoneauth1.exceptions.http import Unauthorized
+    except ImportError:
+        try:
+            from keystoneclient import session as ksc_session
+            from keystoneclient.auth.identity import v3
+
+            legacy_import = True
         except ImportError:
-                try:
-                        from novaclient import client as novaclient
-                        from keystoneclient import session as ksc_session
-                        from keystoneclient.auth.identity import v3
-                        legacy_import = True
-                except ImportError:
-                        fail_usage("Failed: Nova not found or not accessible")
+            fail_usage("Failed: Keystone client not found or not accessible")
 
-        if not legacy_import:
-                loader = loading.get_plugin_loader('password')
-                auth = loader.load_from_options(auth_url=auth_url,
-                                        username=username,
-                                        password=password,
-                                        project_name=projectname,
-                                        user_domain_name=user_domain_name,
-                                        project_domain_name=project_domain_name)
-        else:
-                auth = v3.Password(username=username,
-                                   password=password,
-                                   project_name=projectname,
-                                   user_domain_name=user_domain_name,
-                                   project_domain_name=project_domain_name,
-                                   auth_url=auth_url)
-        session = ksc_session.Session(auth=auth)
-        nova = novaclient.Client("2", session=session)
-        return nova
+    if not legacy_import:
+        loader = loading.get_plugin_loader("password")
+        auth = loader.load_from_options(
+            auth_url=auth_url,
+            username=username,
+            password=password,
+            project_name=projectname,
+            user_domain_name=user_domain_name,
+            project_domain_name=project_domain_name,
+        )
+    else:
+        auth = v3.Password(
+            auth_url=auth_url,
+            username=username,
+            password=password,
+            project_name=projectname,
+            user_domain_name=user_domain_name,
+            project_domain_name=project_domain_name,
+            cacert=cacert,
+        )
 
-def nova_run_command(options,action,timeout=None):
-        username=options["--username"]
-        password=options["--password"]
-        projectname=options["--project-name"]
-        auth_url=options["--auth-url"]
-        user_domain_name=options["--user-domain-name"]
-        project_domain_name=options["--project-domain-name"]
-        novaclient=nova_login(username,password,projectname,auth_url,user_domain_name,project_domain_name)
-        server = novaclient.servers.get(options["--plug"])
-        if action == "status":
-                return server.status
-        if action == "on":
-                server.start()
-        if action == "off":
-                server.stop()
-        if action == "reboot":
-                server.reboot('REBOOT_HARD')
+    session = ksc_session.Session(auth=auth, verify=cacert, timeout=apitimeout)
+    nova = client.Client("2", logger=logger, session=session, timeout=apitimeout)
+    apiversion = None
+    try:
+        apiversion = nova.versions.get_current()
+    except DiscoveryFailure as e:
+        fail_usage("Failed: Discovery Failure: " + str(e))
+    except Unauthorized as e:
+        fail_usage("Failed: Unauthorized: " + str(e))
+    except Exception as e:
+        logger.error(e)
+    logger.debug("Nova version: %s", apiversion)
+    return nova
+
 
 def define_new_opts():
     all_opt["auth-url"] = {
-        "getopt" : ":",
-        "longopt" : "auth-url",
-        "help" : "--auth-url=[authurl]           Keystone Auth URL",
-        "required" : "1",
-        "shortdesc" : "Keystone Auth URL",
-        "order": 1
+        "getopt": ":",
+        "longopt": "auth-url",
+        "help": "--auth-url=[authurl]           Keystone Auth URL",
+        "required": "1",
+        "shortdesc": "Keystone Auth URL",
+        "order": 2,
     }
     all_opt["project-name"] = {
-        "getopt" : ":",
-        "longopt" : "project-name",
-        "help" : "--project-name=[project]       Tenant Or Project Name",
-        "required" : "1",
-        "shortdesc" : "Keystone Project",
+        "getopt": ":",
+        "longopt": "project-name",
+        "help": "--project-name=[project]       Tenant Or Project Name",
+        "required": "1",
+        "shortdesc": "Keystone Project",
         "default": "admin",
-        "order": 1
+        "order": 3,
     }
     all_opt["user-domain-name"] = {
-        "getopt" : ":",
-        "longopt" : "user-domain-name",
-        "help" : "--user-domain-name=[domain]    Keystone User Domain Name",
-        "required" : "0",
-        "shortdesc" : "Keystone User Domain Name",
+        "getopt": ":",
+        "longopt": "user-domain-name",
+        "help": "--user-domain-name=[domain]    Keystone User Domain Name",
+        "required": "0",
+        "shortdesc": "Keystone User Domain Name",
         "default": "Default",
-        "order": 1
+        "order": 4,
     }
     all_opt["project-domain-name"] = {
-        "getopt" : ":",
-        "longopt" : "project-domain-name",
-        "help" : "--project-domain-name=[domain] Keystone Project Domain Name",
-        "required" : "0",
-        "shortdesc" : "Keystone Project Domain Name",
+        "getopt": ":",
+        "longopt": "project-domain-name",
+        "help": "--project-domain-name=[domain] Keystone Project Domain Name",
+        "required": "0",
+        "shortdesc": "Keystone Project Domain Name",
         "default": "Default",
-        "order": 1
+        "order": 5,
     }
     all_opt["uuid"] = {
-        "getopt" : ":",
-        "longopt" : "uuid",
-        "help" : "--uuid=[uuid]                  Replaced by -n, --plug",
-        "required" : "0",
-        "shortdesc" : "Replaced by port/-n/--plug",
-        "order": 1
+        "getopt": ":",
+        "longopt": "uuid",
+        "help": "--uuid=[uuid]                  Replaced by -n, --plug",
+        "required": "0",
+        "shortdesc": "Replaced by port/-n/--plug",
+        "order": 6,
+    }
+    all_opt["cacert"] = {
+        "getopt": ":",
+        "longopt": "cacert",
+        "help": "--cacert=[cacert]              Path to the PEM file with trusted authority certificates",
+        "required": "0",
+        "shortdesc": "SSL X.509 certificates file",
+        "default": "/etc/pki/tls/certs/ca-bundle.crt",
+        "order": 7,
+    }
+    all_opt["apitimeout"] = {
+        "getopt": ":",
+        "type": "second",
+        "longopt": "apitimeout",
+        "help": "--apitimeout=[seconds]         Timeout to use for API calls",
+        "shortdesc": "Timeout in seconds to use for API calls, default is 60.",
+        "required": "0",
+        "default": 60,
+        "order": 8,
     }
 
+
 def main():
+
+    device_opt = [
+        "login",
+        "passwd",
+        "auth-url",
+        "project-name",
+        "user-domain-name",
+        "project-domain-name",
+        "port",
+        "no_port",
+        "uuid",
+        "cacert",
+        "apitimeout",
+    ]
+
     atexit.register(atexit_handler)
 
-    device_opt = [  "login", "passwd", "auth-url", "project-name",
-                    "user-domain-name", "project-domain-name",
-                    "port", "no_port", "uuid" ]
     define_new_opts()
 
-    all_opt["port"]["required"] = "0"
-    all_opt["port"]["help"] = "-n, --plug=[UUID]              UUID of the node to be fenced"
-    all_opt["port"]["shortdesc"] = "UUID of the node to be fenced."
+    all_opt["power_timeout"]["default"] = "60"
 
     options = check_input(device_opt, process_input(device_opt))
-
-    # hack to remove list/list-status actions which are not supported
-    options["device_opt"] = [ o for o in options["device_opt"] if o != "separator" ]
 
     # workaround to avoid regressions
     if "--uuid" in options:
         options["--plug"] = options["--uuid"]
         del options["--uuid"]
-    elif "--help" not in options and options["--action"] in ["off", "on", \
-         "reboot", "status", "validate-all"] and "--plug" not in options:
+    elif (
+        "--help" not in options
+        and options["--action"] in ["off", "on", "reboot", "status", "validate-all"]
+        and "--plug" not in options
+    ):
         stop_after_error = False if options["--action"] == "validate-all" else True
-        fail_usage("Failed: You have to enter plug number or machine identification", stop_after_error)
+        fail_usage(
+            "Failed: You have to enter plug number or machine identification",
+            stop_after_error,
+        )
 
     docs = {}
     docs["shortdesc"] = "Fence agent for OpenStack's Nova service"
-    docs["longdesc"] = "fence_openstack is a Fencing agent \
+    docs[
+        "longdesc"
+    ] = "fence_openstack is a Fencing agent \
 which can be used with machines controlled by the Openstack's Nova service. \
 This agent calls the python-novaclient and it is mandatory to be installed "
     docs["vendorurl"] = "https://wiki.openstack.org/wiki/Nova"
@@ -154,9 +271,37 @@ This agent calls the python-novaclient and it is mandatory to be installed "
 
     run_delay(options)
 
-    result = fence_action(None, options, set_power_status, get_power_status,None)
+    username = options["--username"]
+    password = options["--password"]
+    projectname = options["--project-name"]
+    auth_url = None
+    try:
+        auth_url = options["--auth-url"]
+    except KeyError:
+        fail_usage(
+            "Failed: You have to set the Keystone service endpoint for authorization"
+        )
+    user_domain_name = options["--user-domain-name"]
+    project_domain_name = options["--project-domain-name"]
+    cacert = options["--cacert"]
+    apitimeout = options["--apitimeout"]
+    conn = nova_login(
+        username,
+        password,
+        projectname,
+        auth_url,
+        user_domain_name,
+        project_domain_name,
+        cacert,
+        apitimeout,
+    )
+
+    # Operate the fencing device
+    result = fence_action(
+        conn, options, set_power_status, get_power_status, get_nodes_list
+    )
     sys.exit(result)
+
 
 if __name__ == "__main__":
     main()
-

--- a/agents/openstack/fence_openstack.py
+++ b/agents/openstack/fence_openstack.py
@@ -235,6 +235,11 @@ def main():
 
     define_new_opts()
 
+    all_opt["port"]["required"] = "0"
+    all_opt["port"][
+        "help"
+    ] = "-n, --plug=[UUID]              UUID of the node to be fenced"
+    all_opt["port"]["shortdesc"] = "UUID of the node to be fenced."
     all_opt["power_timeout"]["default"] = "60"
 
     options = check_input(device_opt, process_input(device_opt))

--- a/agents/openstack/fence_openstack.py
+++ b/agents/openstack/fence_openstack.py
@@ -236,9 +236,7 @@ def main():
     define_new_opts()
 
     all_opt["port"]["required"] = "0"
-    all_opt["port"][
-        "help"
-    ] = "-n, --plug=[UUID]              UUID of the node to be fenced"
+    all_opt["port"]["help"] = "-n, --plug=[UUID]              UUID of the node to be fenced"
     all_opt["port"]["shortdesc"] = "UUID of the node to be fenced."
     all_opt["power_timeout"]["default"] = "60"
 
@@ -278,9 +276,7 @@ This agent calls the python-novaclient and it is mandatory to be installed "
     try:
         auth_url = options["--auth-url"]
     except KeyError:
-        fail_usage(
-            "Failed: You have to set the Keystone service endpoint for authorization"
-        )
+        fail_usage("Failed: You have to set the Keystone service endpoint for authorization")
     user_domain_name = options["--user-domain-name"]
     project_domain_name = options["--project-domain-name"]
     cacert = options["--cacert"]
@@ -297,9 +293,7 @@ This agent calls the python-novaclient and it is mandatory to be installed "
     )
 
     # Operate the fencing device
-    result = fence_action(
-        conn, options, set_power_status, get_power_status, get_nodes_list
-    )
+    result = fence_action(conn, options, set_power_status, get_power_status, get_nodes_list)
     sys.exit(result)
 
 

--- a/agents/openstack/fence_openstack.py
+++ b/agents/openstack/fence_openstack.py
@@ -88,16 +88,8 @@ def set_power_status(conn, options):
         logging.info("Called reboot hard API call for " + server.id)
 
 
-def nova_login(
-    username,
-    password,
-    projectname,
-    auth_url,
-    user_domain_name,
-    project_domain_name,
-    cacert,
-    apitimeout,
-):
+def nova_login(username, password, projectname, auth_url, user_domain_name,
+               project_domain_name, cacert, apitimeout):
     legacy_import = False
 
     try:
@@ -247,11 +239,9 @@ def main():
     if "--uuid" in options:
         options["--plug"] = options["--uuid"]
         del options["--uuid"]
-    elif (
-        "--help" not in options
-        and options["--action"] in ["off", "on", "reboot", "status", "validate-all"]
-        and "--plug" not in options
-    ):
+    elif ("--help" not in options
+          and options["--action"] in ["off", "on", "reboot", "status", "validate-all"]
+          and "--plug" not in options):
         stop_after_error = False if options["--action"] == "validate-all" else True
         fail_usage(
             "Failed: You have to enter plug number or machine identification",
@@ -260,9 +250,7 @@ def main():
 
     docs = {}
     docs["shortdesc"] = "Fence agent for OpenStack's Nova service"
-    docs[
-        "longdesc"
-    ] = "fence_openstack is a Fencing agent \
+    docs["longdesc"] = "fence_openstack is a Fencing agent \
 which can be used with machines controlled by the Openstack's Nova service. \
 This agent calls the python-novaclient and it is mandatory to be installed "
     docs["vendorurl"] = "https://wiki.openstack.org/wiki/Nova"

--- a/lib/fencing.py.py
+++ b/lib/fencing.py.py
@@ -15,7 +15,8 @@ import itertools
 RELEASE_VERSION = "@RELEASE_VERSION@"
 
 __all__ = ['atexit_handler', 'check_input', 'process_input', 'all_opt', 'show_docs',
-		'fence_login', 'fence_action', 'fence_logout']
+           'fence_login', 'fence_action', 'fence_logout', 'fail_usage', 'run_delay',
+           'SyslogLibHandler']
 
 EC_OK = 0
 EC_GENERIC_ERROR = 1

--- a/lib/fencing.py.py
+++ b/lib/fencing.py.py
@@ -15,8 +15,7 @@ import itertools
 RELEASE_VERSION = "@RELEASE_VERSION@"
 
 __all__ = ['atexit_handler', 'check_input', 'process_input', 'all_opt', 'show_docs',
-           'fence_login', 'fence_action', 'fence_logout', 'fail_usage', 'run_delay',
-           'SyslogLibHandler']
+		'fence_login', 'fence_action', 'fence_logout']
 
 EC_OK = 0
 EC_GENERIC_ERROR = 1

--- a/tests/data/metadata/fence_openstack.xml
+++ b/tests/data/metadata/fence_openstack.xml
@@ -33,15 +33,15 @@
 		<content type="string"  />
 		<shortdesc lang="en">Script to run to retrieve password</shortdesc>
 	</parameter>
-	<parameter name="plug" unique="0" required="1" obsoletes="port">
-		<getopt mixed="-n, --plug=[id]" />
+	<parameter name="plug" unique="0" required="0" obsoletes="port">
+		<getopt mixed="-n, --plug=[UUID]" />
 		<content type="string"  />
-		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
+		<shortdesc lang="en">UUID of the node to be fenced.</shortdesc>
 	</parameter>
-	<parameter name="port" unique="0" required="1" deprecated="1">
-		<getopt mixed="-n, --plug=[id]" />
+	<parameter name="port" unique="0" required="0" deprecated="1">
+		<getopt mixed="-n, --plug=[UUID]" />
 		<content type="string"  />
-		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
+		<shortdesc lang="en">UUID of the node to be fenced.</shortdesc>
 	</parameter>
 	<parameter name="username" unique="0" required="1" obsoletes="login">
 		<getopt mixed="-l, --username=[name]" />

--- a/tests/data/metadata/fence_openstack.xml
+++ b/tests/data/metadata/fence_openstack.xml
@@ -8,16 +8,6 @@
 		<content type="string" default="reboot"  />
 		<shortdesc lang="en">Fencing action</shortdesc>
 	</parameter>
-	<parameter name="auth-url" unique="0" required="1" deprecated="1">
-		<getopt mixed="--auth-url=[authurl]" />
-		<content type="string"  />
-		<shortdesc lang="en">Keystone Auth URL</shortdesc>
-	</parameter>
-	<parameter name="auth_url" unique="0" required="1" obsoletes="auth-url">
-		<getopt mixed="--auth-url=[authurl]" />
-		<content type="string"  />
-		<shortdesc lang="en">Keystone Auth URL</shortdesc>
-	</parameter>
 	<parameter name="login" unique="0" required="1" deprecated="1">
 		<getopt mixed="-l, --username=[name]" />
 		<content type="string"  />
@@ -43,30 +33,35 @@
 		<content type="string"  />
 		<shortdesc lang="en">Script to run to retrieve password</shortdesc>
 	</parameter>
-	<parameter name="plug" unique="0" required="0" obsoletes="port">
-		<getopt mixed="-n, --plug=[UUID]" />
+	<parameter name="plug" unique="0" required="1" obsoletes="port">
+		<getopt mixed="-n, --plug=[id]" />
 		<content type="string"  />
-		<shortdesc lang="en">UUID of the node to be fenced.</shortdesc>
+		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
 	</parameter>
-	<parameter name="port" unique="0" required="0" deprecated="1">
-		<getopt mixed="-n, --plug=[UUID]" />
+	<parameter name="port" unique="0" required="1" deprecated="1">
+		<getopt mixed="-n, --plug=[id]" />
 		<content type="string"  />
-		<shortdesc lang="en">UUID of the node to be fenced.</shortdesc>
+		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
 	</parameter>
-	<parameter name="project-domain-name" unique="0" required="0" deprecated="1">
-		<getopt mixed="--project-domain-name=[domain]" />
-		<content type="string" default="Default"  />
-		<shortdesc lang="en">Keystone Project Domain Name</shortdesc>
+	<parameter name="username" unique="0" required="1" obsoletes="login">
+		<getopt mixed="-l, --username=[name]" />
+		<content type="string"  />
+		<shortdesc lang="en">Login name</shortdesc>
+	</parameter>
+	<parameter name="auth-url" unique="0" required="1" deprecated="1">
+		<getopt mixed="--auth-url=[authurl]" />
+		<content type="string"  />
+		<shortdesc lang="en">Keystone Auth URL</shortdesc>
+	</parameter>
+	<parameter name="auth_url" unique="0" required="1" obsoletes="auth-url">
+		<getopt mixed="--auth-url=[authurl]" />
+		<content type="string"  />
+		<shortdesc lang="en">Keystone Auth URL</shortdesc>
 	</parameter>
 	<parameter name="project-name" unique="0" required="1" deprecated="1">
 		<getopt mixed="--project-name=[project]" />
 		<content type="string" default="admin"  />
 		<shortdesc lang="en">Keystone Project</shortdesc>
-	</parameter>
-	<parameter name="project_domain_name" unique="0" required="0" obsoletes="project-domain-name">
-		<getopt mixed="--project-domain-name=[domain]" />
-		<content type="string" default="Default"  />
-		<shortdesc lang="en">Keystone Project Domain Name</shortdesc>
 	</parameter>
 	<parameter name="project_name" unique="0" required="1" obsoletes="project-name">
 		<getopt mixed="--project-name=[project]" />
@@ -83,15 +78,30 @@
 		<content type="string" default="Default"  />
 		<shortdesc lang="en">Keystone User Domain Name</shortdesc>
 	</parameter>
-	<parameter name="username" unique="0" required="1" obsoletes="login">
-		<getopt mixed="-l, --username=[name]" />
-		<content type="string"  />
-		<shortdesc lang="en">Login name</shortdesc>
+	<parameter name="project-domain-name" unique="0" required="0" deprecated="1">
+		<getopt mixed="--project-domain-name=[domain]" />
+		<content type="string" default="Default"  />
+		<shortdesc lang="en">Keystone Project Domain Name</shortdesc>
+	</parameter>
+	<parameter name="project_domain_name" unique="0" required="0" obsoletes="project-domain-name">
+		<getopt mixed="--project-domain-name=[domain]" />
+		<content type="string" default="Default"  />
+		<shortdesc lang="en">Keystone Project Domain Name</shortdesc>
 	</parameter>
 	<parameter name="uuid" unique="0" required="0">
 		<getopt mixed="--uuid=[uuid]" />
 		<content type="string"  />
 		<shortdesc lang="en">Replaced by port/-n/--plug</shortdesc>
+	</parameter>
+	<parameter name="cacert" unique="0" required="0">
+		<getopt mixed="--cacert=[cacert]" />
+		<content type="string" default="/etc/pki/tls/certs/ca-bundle.crt"  />
+		<shortdesc lang="en">SSL X.509 certificates file</shortdesc>
+	</parameter>
+	<parameter name="apitimeout" unique="0" required="0">
+		<getopt mixed="--apitimeout=[seconds]" />
+		<content type="second" default="60"  />
+		<shortdesc lang="en">Timeout in seconds to use for API calls, default is 60.</shortdesc>
 	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
@@ -128,6 +138,11 @@
 		<content type="boolean"  />
 		<shortdesc lang="en">Display help and exit</shortdesc>
 	</parameter>
+	<parameter name="separator" unique="0" required="0">
+		<getopt mixed="-C, --separator=[char]" />
+		<content type="string" default=","  />
+		<shortdesc lang="en">Separator for CSV created by 'list' operation</shortdesc>
+	</parameter>
 	<parameter name="delay" unique="0" required="0">
 		<getopt mixed="--delay=[seconds]" />
 		<content type="second" default="0"  />
@@ -145,7 +160,7 @@
 	</parameter>
 	<parameter name="power_timeout" unique="0" required="0">
 		<getopt mixed="--power-timeout=[seconds]" />
-		<content type="second" default="20"  />
+		<content type="second" default="60"  />
 		<shortdesc lang="en">Test X seconds for status change after ON/OFF</shortdesc>
 	</parameter>
 	<parameter name="power_wait" unique="0" required="0">
@@ -169,6 +184,8 @@
 	<action name="off" />
 	<action name="reboot" />
 	<action name="status" />
+	<action name="list" />
+	<action name="list-status" />
 	<action name="monitor" />
 	<action name="metadata" />
 	<action name="manpage" />


### PR DESCRIPTION
* Remove unnecessary imports
* Change path append to macro
* Check for novaclient import separate from keystoneclient
* Ignore urllib3 warnings due to self-signed certificates
* Enable logging to syslog
* Add list and list-status functionality
* Deal with many more client exceptions
* Change from REBOOT_HARD to HARD due to API change
* Replace nova_run_command with get_power_status and set_power_status
* Added cacert option to authenticate against self-signed certificates
* Added apitimeout to pass to the client session