### PR TITLE
fence_azure_arm: corrections to support Azure SDK >= 15

### DIFF
--- a/agents/azure_arm/fence_azure_arm.py
+++ b/agents/azure_arm/fence_azure_arm.py
@@ -115,7 +115,7 @@ def set_power_status(clients, options):
 
         if (options["--action"]=="off"):
             logging.info("Poweroff " + vmName + " in resource group " + rgName)
-            compute_client.virtual_machines.power_off(rgName, vmName, skip_shutdown=True)
+            compute_client.virtual_machines.begin_power_off(rgName, vmName, skip_shutdown=True)
         elif (options["--action"]=="on"):
             logging.info("Starting " + vmName + " in resource group " + rgName)
             compute_client.virtual_machines.start(rgName, vmName)

--- a/lib/azure_fence.py.py
+++ b/lib/azure_fence.py.py
@@ -292,19 +292,19 @@ def get_azure_credentials(config):
         from msrestazure.azure_active_directory import MSIAuthentication
         credentials = MSIAuthentication()
     elif cloud_environment:
-        from azure.common.credentials import ServicePrincipalCredentials
-        credentials = ServicePrincipalCredentials(
+        from azure.identity import ClientSecretCredential
+        credentials = ClientSecretCredential(
             client_id = config.ApplicationId,
-            secret = config.ApplicationKey,
-            tenant = config.Tenantid,
+            client_secret = config.ApplicationKey,
+            tenant_id = config.Tenantid,
             cloud_environment=cloud_environment
         )
     else:
-        from azure.common.credentials import ServicePrincipalCredentials
-        credentials = ServicePrincipalCredentials(
+        from azure.identity import ClientSecretCredential
+        credentials = ClientSecretCredential(
             client_id = config.ApplicationId,
-            secret = config.ApplicationKey,
-            tenant = config.Tenantid
+            client_secret = config.ApplicationKey,
+            tenant_id = config.Tenantid
         )
 
     return credentials


### PR DESCRIPTION
We have found that fence_azure_arm do not work after Azure SDK >= 15.
We initiated this PR to report the problem and part of the solutions because there are other points that need attention.
Below are them:
1) Back support to older versions of Azure SDK < 15. Code must be improved to detect the version that is running and select functions accordingly.
2) Other functions from agent were not tested yet, but could suffer from same changes in SDK.
Contributions and comments are welcome.