### PR TITLE
fence_azure_arm: corrections to support Azure SDK >= 15 - including backward compatibility

### DIFF
--- a/agents/azure_arm/fence_azure_arm.py
+++ b/agents/azure_arm/fence_azure_arm.py
@@ -120,7 +120,7 @@ def set_power_status(clients, options):
                 compute_client.virtual_machines.begin_power_off(rgName, vmName, skip_shutdown=True)
             except AttributeError:
                 # use older API verson if it fails
-                logging.info("Poweroff " + vmName + " did not work via 'virtual_machines.begin_power_off. Trying virtual_machines.power_off'.")
+                logging.debug("Poweroff " + vmName + " did not work via 'virtual_machines.begin_power_off. Trying virtual_machines.power_off'.")
                 compute_client.virtual_machines.power_off(rgName, vmName, skip_shutdown=True)
         elif (options["--action"]=="on"):
             logging.info("Starting " + vmName + " in resource group " + rgName)
@@ -129,7 +129,7 @@ def set_power_status(clients, options):
                 compute_client.virtual_machines.begin_start(rgName, vmName)
             except AttributeError:
                 # use older API verson if it fails
-                logging.info("Starting " + vmName + " did not work via 'virtual_machines.begin_start. Trying virtual_machines.start'.")
+                logging.debug("Starting " + vmName + " did not work via 'virtual_machines.begin_start. Trying virtual_machines.start'.")
                 compute_client.virtual_machines.start(rgName, vmName)
 
 

--- a/agents/azure_arm/fence_azure_arm.py
+++ b/agents/azure_arm/fence_azure_arm.py
@@ -115,10 +115,22 @@ def set_power_status(clients, options):
 
         if (options["--action"]=="off"):
             logging.info("Poweroff " + vmName + " in resource group " + rgName)
-            compute_client.virtual_machines.begin_power_off(rgName, vmName, skip_shutdown=True)
+            # use older API version first
+            try:
+                compute_client.virtual_machines.power_off(rgName, vmName, skip_shutdown=True)
+            # try new API version if it fails
+            except AttributeError:
+                logging.info("Poweroff " + vmName + " did not work via 'virtual_machines.power_off. Trying virtual_machines.begin_power_off'.")
+                compute_client.virtual_machines.begin_power_off(rgName, vmName, skip_shutdown=True)
         elif (options["--action"]=="on"):
             logging.info("Starting " + vmName + " in resource group " + rgName)
-            compute_client.virtual_machines.start(rgName, vmName)
+            # use older API version first
+            try:
+                compute_client.virtual_machines.start(rgName, vmName)
+            # try new API version if it fails
+            except AttributeError:
+                logging.info("Starting " + vmName + " did not work via 'virtual_machines.start. Trying virtual_machines.begin_start'.")
+                compute_client.virtual_machines.begin_start(rgName, vmName)
 
 
 def define_new_opts():

--- a/agents/azure_arm/fence_azure_arm.py
+++ b/agents/azure_arm/fence_azure_arm.py
@@ -115,7 +115,7 @@ def set_power_status(clients, options):
 
         if (options["--action"]=="off"):
             logging.info("Poweroff " + vmName + " in resource group " + rgName)
-            compute_client.virtual_machines.power_off(rgName, vmName, skip_shutdown=True)
+            compute_client.virtual_machines.begin_power_off(rgName, vmName, skip_shutdown=True)
         elif (options["--action"]=="on"):
             logging.info("Starting " + vmName + " in resource group " + rgName)
             compute_client.virtual_machines.start(rgName, vmName)

--- a/agents/azure_arm/fence_azure_arm.py
+++ b/agents/azure_arm/fence_azure_arm.py
@@ -115,22 +115,22 @@ def set_power_status(clients, options):
 
         if (options["--action"]=="off"):
             logging.info("Poweroff " + vmName + " in resource group " + rgName)
-            # use older API version first
             try:
-                compute_client.virtual_machines.power_off(rgName, vmName, skip_shutdown=True)
-            # try new API version if it fails
-            except AttributeError:
-                logging.info("Poweroff " + vmName + " did not work via 'virtual_machines.power_off. Trying virtual_machines.begin_power_off'.")
+                # try new API version first
                 compute_client.virtual_machines.begin_power_off(rgName, vmName, skip_shutdown=True)
+            except AttributeError:
+                # use older API verson if it fails
+                logging.info("Poweroff " + vmName + " did not work via 'virtual_machines.begin_power_off. Trying virtual_machines.power_off'.")
+                compute_client.virtual_machines.power_off(rgName, vmName, skip_shutdown=True)
         elif (options["--action"]=="on"):
             logging.info("Starting " + vmName + " in resource group " + rgName)
-            # use older API version first
             try:
-                compute_client.virtual_machines.start(rgName, vmName)
-            # try new API version if it fails
-            except AttributeError:
-                logging.info("Starting " + vmName + " did not work via 'virtual_machines.start. Trying virtual_machines.begin_start'.")
+                # try new API version first
                 compute_client.virtual_machines.begin_start(rgName, vmName)
+            except AttributeError:
+                # use older API verson if it fails
+                logging.info("Starting " + vmName + " did not work via 'virtual_machines.begin_start. Trying virtual_machines.start'.")
+                compute_client.virtual_machines.start(rgName, vmName)
 
 
 def define_new_opts():

--- a/lib/azure_fence.py.py
+++ b/lib/azure_fence.py.py
@@ -1,6 +1,5 @@
 import logging, re, time
 from fencing import fail_usage
-import os
 
 FENCE_SUBNET_NAME = "fence-subnet"
 FENCE_INBOUND_RULE_NAME = "FENCE_DENY_ALL_INBOUND"

--- a/lib/azure_fence.py.py
+++ b/lib/azure_fence.py.py
@@ -292,19 +292,19 @@ def get_azure_credentials(config):
         from msrestazure.azure_active_directory import MSIAuthentication
         credentials = MSIAuthentication()
     elif cloud_environment:
-        from azure.common.credentials import ServicePrincipalCredentials
-        credentials = ServicePrincipalCredentials(
+        from azure.identity import ClientSecretCredential
+        credentials = ClientSecretCredential(
             client_id = config.ApplicationId,
-            secret = config.ApplicationKey,
-            tenant = config.Tenantid,
+            client_secret = config.ApplicationKey,
+            tenant_id = config.Tenantid,
             cloud_environment=cloud_environment
         )
     else:
-        from azure.common.credentials import ServicePrincipalCredentials
-        credentials = ServicePrincipalCredentials(
+        from azure.identity import ClientSecretCredential
+        credentials = ClientSecretCredential(
             client_id = config.ApplicationId,
-            secret = config.ApplicationKey,
-            tenant = config.Tenantid
+            client_secret = config.ApplicationKey,
+            tenant_id = config.Tenantid
         )
 
     return credentials


### PR DESCRIPTION
This is based on the work in #410.
It adds some code to check for the possibility to import some modules and access some attributes.
It tries to use the newer module `azure.identity / azure.core` first and falls back to `azure.common` if this fails.

This is not the approach mentioned e.g. here https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate#other-authentication-methods / https://gist.github.com/lmazuel/cc683d82ea1d7b40208de7c9fc8de59d or here https://github.com/jongio/azidext/blob/master/python/azure_identity_credential_adapter.py.
The obove approaches did not work out as they import again `azure.core.pipeline` which is only available with newer API versions.

My test systems which run this code flawlessly are:

```
# SUSE Linux Enterprise Server 12 SP3
# python2
sles12sp3:~ # rpm -q python-azure-mgmt python-azure-mgmt-compute python-azure-mgmt-resource
python-azure-mgmt-4.0.0-2.10.1.noarch
python-azure-mgmt-compute-4.6.2-2.6.3.noarch
python-azure-mgmt-resource-2.0.0-2.6.2.noarch

# SUSE Linux Enterprise Server 15 SP2
# python3
sles15sp2:~ # rpm -q python3-azure-mgmt-core python3-azure-mgmt-compute python3-azure-mgmt-resource
python3-azure-mgmt-core-1.2.2-3.3.1.noarch
python3-azure-mgmt-compute-17.0.0-6.7.1.noarch
python3-azure-mgmt-resource-10.2.0-6.4.1.noarch
```

