### PR TITLE
fence_cdu: new fence agent

### DIFF
--- a/agents/cdu/fence_cdu.py
+++ b/agents/cdu/fence_cdu.py
@@ -1,0 +1,135 @@
+#!@PYTHON@ -tt
+#    fence_cdu - fence agent for a Sentry Switch CDU.
+#
+#    Copyright (C) 2012 Canonical Ltd.
+#    Copyright (C) 2021 SUSE Linux GmbH <trenn@suse.de>
+#
+#    Authors: Andres Rodriguez <andres.rodriguez@canonical.com>
+#             Thomas Renninger <trenn@suse.de>
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, version 3 of the License.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#####
+##
+## The Following Agent Has Been Tested On:
+##
+##  Model                Firmware
+## +---------------------------------------------+
+## Sentry Switched CDU   6a
+## Sentry Switched CDU   7.1c <trenn@suse.de>
+##
+##
+#####
+
+import sys, re, pexpect, atexit
+sys.path.append("@FENCEAGENTSLIBDIR@")
+from fencing import *
+from fencing import fail, EC_TIMED_OUT, run_command, frun
+
+def get_power_status(conn, options):
+    exp_result = 0
+    outlets = {}
+    try:
+        conn.send("STATUS\r\n")
+        conn.log_expect(options["--command-prompt"], int(options["--shell-timeout"]))
+        lines = conn.before.split("\n")
+        #    .A12     TowerA_Outlet12           On         Idle On  
+        #    .A12     test-01                   On         Idle On  
+        show_re = re.compile('(\.\w+)\s+(\w+|\w+\W\w+)\s+(On|Off)\s+(On|Idle On|Off|Wake On)')
+        for line in lines:
+            res = show_re.search(line)
+            if res != None:
+                outlets[res.group(2)] = (res.group(1), res.group(3))
+    except pexpect.EOF:
+        fail(EC_CONNECTION_LOST)
+    except pexpect.TIMEOUT:
+        fail(EC_TIMED_OUT)
+    try:
+        (_, status) = outlets[options["--plug"]]
+        return status.lower().strip()
+    except KeyError:
+        fail(EC_STATUS)
+
+def set_power_status(conn, options):
+        outlets = {}
+        action = { 'on' : "on", 'off': "off" }[options["--action"]]
+        try:
+            conn.send("LIST OUTLETS\r\n")
+            conn.log_expect(options["--command-prompt"], int(options["--shell-timeout"]))
+            lines = conn.before.split("\n")
+            #    .A12     TowerA_Outlet12
+            #    .A12     test-01
+            show_re = re.compile('(\.\w+)\s+(\w+|\w+\W\w+)\s+')
+            for line in lines:
+                res = show_re.search(line)
+                if res != None:
+                    outlets[res.group(2)] = (res.group(1))
+            conn.send(action + " " + outlets[options["--plug"]] + "\r\n")
+            conn.log_expect(options["--command-prompt"], int(options["--shell-timeout"]))
+        except pexpect.EOF:
+            fail(EC_CONNECTION_LOST)
+        except pexpect.TIMEOUT:
+            fail(EC_TIMED_OUT)
+
+def disconnect(conn):
+    conn.sendline("LOGOUT")
+    conn.close()
+
+def main():
+    device_opt = [  "ipaddr", "login", "port", "switch", "passwd", "telnet" ]
+
+    atexit.register(atexit_handler)
+
+    options = check_input(device_opt, process_input(device_opt))
+
+    ##
+    ## Fence agent specific defaults
+    #####
+    options["--command-prompt"] = "Switched CDU:"
+
+    docs = { }
+    docs["shortdesc"] = "Fence agent for a Sentry Switch CDU over telnet"
+    docs["longdesc"] = "fence_cdu is an I/O Fencing agent \
+which can be used with the Sentry Switch CDU. It logs into the device \
+via telnet and power's on/off an outlet."
+    docs["vendorurl"] = "http://www.servertech.com"
+    show_docs(options, docs)
+
+    ## Support for --plug [switch]:[plug] notation that was used before
+    opt_n = options.get("--plug")
+    if opt_n and (-1 != opt_n.find(":")):
+        (switch, plug) = opt_n.split(":", 1)
+        options["--switch"] = switch;
+        options["--plug"] = plug;
+
+    ##
+    ## Operate the fencing device
+    ####
+    conn = fence_login(options)
+    # disable output paging
+    conn.sendline("set option more disabled")
+    conn.log_expect(options["--command-prompt"], int(options["--login-timeout"]))
+    result = fence_action(conn, options, set_power_status, get_power_status, get_power_status)
+    ##
+    ## Logout from system
+    ##
+    ## In some special unspecified cases it is possible that
+    ## connection will be closed before we run close(). This is not
+    ## a problem because everything is checked before.
+    ######
+    atexit.register(disconnect, conn)
+
+    sys.exit(result)
+
+if __name__ == "__main__":
+    main()

--- a/fence-agents.spec.in
+++ b/fence-agents.spec.in
@@ -41,6 +41,7 @@ fence-agents-aws \\
 fence-agents-azure-arm \\
 fence-agents-bladecenter \\
 fence-agents-brocade \\
+fence-agents-cdu \\
 fence-agents-cisco-mds \\
 fence-agents-cisco-ucs \\
 fence-agents-docker \\
@@ -459,6 +460,17 @@ Fence agent for Brocade devices that are accessed via telnet or SSH.
 %files brocade
 %{_sbindir}/fence_brocade
 %{_mandir}/man8/fence_brocade.8*
+
+%package cdu
+License: GPLv3-only
+Summary: Fence agent for a Sentry Switch CDU
+Requires: fence-agents-common = %{version}-%{release}
+BuildArch: noarch
+%description cdu
+Fence agent for Sentry Switch CDU power switch.
+%files cdu
+%{_sbindir}/fence_cdu
+%{_mandir}/man8/fence_cdu.8*
 
 %package cisco-mds
 License: GPLv2+ and LGPLv2+

--- a/tests/data/metadata/fence_cdu.xml
+++ b/tests/data/metadata/fence_cdu.xml
@@ -1,0 +1,168 @@
+<?xml version="1.0" ?>
+<resource-agent name="fence_cdu" shortdesc="Fence agent for a Sentry Switch CDU over telnet" >
+<longdesc>fence_cdu is an I/O Fencing agent which can be used with the Sentry Switch CDU. It logs into the device via telnet and power's on/off an outlet.</longdesc>
+<vendor-url>http://www.servertech.com</vendor-url>
+<parameters>
+	<parameter name="action" unique="0" required="1">
+		<getopt mixed="-o, --action=[action]" />
+		<content type="string" default="reboot"  />
+		<shortdesc lang="en">Fencing action</shortdesc>
+	</parameter>
+	<parameter name="ip" unique="0" required="1" obsoletes="ipaddr">
+		<getopt mixed="-a, --ip=[ip]" />
+		<content type="string"  />
+		<shortdesc lang="en">IP address or hostname of fencing device</shortdesc>
+	</parameter>
+	<parameter name="ipaddr" unique="0" required="1" deprecated="1">
+		<getopt mixed="-a, --ip=[ip]" />
+		<content type="string"  />
+		<shortdesc lang="en">IP address or hostname of fencing device</shortdesc>
+	</parameter>
+	<parameter name="ipport" unique="0" required="0">
+		<getopt mixed="-u, --ipport=[port]" />
+		<content type="integer" default="23"  />
+		<shortdesc lang="en">TCP/UDP port to use for connection with device</shortdesc>
+	</parameter>
+	<parameter name="login" unique="0" required="1" deprecated="1">
+		<getopt mixed="-l, --username=[name]" />
+		<content type="string"  />
+		<shortdesc lang="en">Login name</shortdesc>
+	</parameter>
+	<parameter name="passwd" unique="0" required="0" deprecated="1">
+		<getopt mixed="-p, --password=[password]" />
+		<content type="string"  />
+		<shortdesc lang="en">Login password or passphrase</shortdesc>
+	</parameter>
+	<parameter name="passwd_script" unique="0" required="0" deprecated="1">
+		<getopt mixed="-S, --password-script=[script]" />
+		<content type="string"  />
+		<shortdesc lang="en">Script to run to retrieve password</shortdesc>
+	</parameter>
+	<parameter name="password" unique="0" required="0" obsoletes="passwd">
+		<getopt mixed="-p, --password=[password]" />
+		<content type="string"  />
+		<shortdesc lang="en">Login password or passphrase</shortdesc>
+	</parameter>
+	<parameter name="password_script" unique="0" required="0" obsoletes="passwd_script">
+		<getopt mixed="-S, --password-script=[script]" />
+		<content type="string"  />
+		<shortdesc lang="en">Script to run to retrieve password</shortdesc>
+	</parameter>
+	<parameter name="plug" unique="0" required="1" obsoletes="port">
+		<getopt mixed="-n, --plug=[id]" />
+		<content type="string"  />
+		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
+	</parameter>
+	<parameter name="port" unique="0" required="1" deprecated="1">
+		<getopt mixed="-n, --plug=[id]" />
+		<content type="string"  />
+		<shortdesc lang="en">Physical plug number on device, UUID or identification of machine</shortdesc>
+	</parameter>
+	<parameter name="switch" unique="0" required="0">
+		<getopt mixed="-s, --switch=[id]" />
+		<content type="string"  />
+		<shortdesc lang="en">Physical switch number on device</shortdesc>
+	</parameter>
+	<parameter name="username" unique="0" required="1" obsoletes="login">
+		<getopt mixed="-l, --username=[name]" />
+		<content type="string"  />
+		<shortdesc lang="en">Login name</shortdesc>
+	</parameter>
+	<parameter name="quiet" unique="0" required="0">
+		<getopt mixed="-q, --quiet" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Disable logging to stderr. Does not affect --verbose or --debug-file or logging to syslog.</shortdesc>
+	</parameter>
+	<parameter name="verbose" unique="0" required="0">
+		<getopt mixed="-v, --verbose" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Verbose mode. Multiple -v flags can be stacked on the command line (e.g., -vvv) to increase verbosity.</shortdesc>
+	</parameter>
+	<parameter name="verbose_level" unique="0" required="0">
+		<getopt mixed="--verbose-level" />
+		<content type="integer"  />
+		<shortdesc lang="en">Level of debugging detail in output. Defaults to the number of --verbose flags specified on the command line, or to 1 if verbose=1 in a stonith device configuration (i.e., on stdin).</shortdesc>
+	</parameter>
+	<parameter name="debug" unique="0" required="0" deprecated="1">
+		<getopt mixed="-D, --debug-file=[debugfile]" />
+		<content type="string"  />
+		<shortdesc lang="en">Write debug information to given file</shortdesc>
+	</parameter>
+	<parameter name="debug_file" unique="0" required="0" obsoletes="debug">
+		<getopt mixed="-D, --debug-file=[debugfile]" />
+		<content type="string"  />
+		<shortdesc lang="en">Write debug information to given file</shortdesc>
+	</parameter>
+	<parameter name="version" unique="0" required="0">
+		<getopt mixed="-V, --version" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Display version information and exit</shortdesc>
+	</parameter>
+	<parameter name="help" unique="0" required="0">
+		<getopt mixed="-h, --help" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Display help and exit</shortdesc>
+	</parameter>
+	<parameter name="separator" unique="0" required="0">
+		<getopt mixed="-C, --separator=[char]" />
+		<content type="string" default=","  />
+		<shortdesc lang="en">Separator for CSV created by 'list' operation</shortdesc>
+	</parameter>
+	<parameter name="delay" unique="0" required="0">
+		<getopt mixed="--delay=[seconds]" />
+		<content type="second" default="0"  />
+		<shortdesc lang="en">Wait X seconds before fencing is started</shortdesc>
+	</parameter>
+	<parameter name="disable_timeout" unique="0" required="0">
+		<getopt mixed="--disable-timeout=[true/false]" />
+		<content type="string"  />
+		<shortdesc lang="en">Disable timeout (true/false) (default: true when run from Pacemaker 2.0+)</shortdesc>
+	</parameter>
+	<parameter name="login_timeout" unique="0" required="0">
+		<getopt mixed="--login-timeout=[seconds]" />
+		<content type="second" default="5"  />
+		<shortdesc lang="en">Wait X seconds for cmd prompt after login</shortdesc>
+	</parameter>
+	<parameter name="power_timeout" unique="0" required="0">
+		<getopt mixed="--power-timeout=[seconds]" />
+		<content type="second" default="20"  />
+		<shortdesc lang="en">Test X seconds for status change after ON/OFF</shortdesc>
+	</parameter>
+	<parameter name="power_wait" unique="0" required="0">
+		<getopt mixed="--power-wait=[seconds]" />
+		<content type="second" default="0"  />
+		<shortdesc lang="en">Wait X seconds after issuing ON/OFF</shortdesc>
+	</parameter>
+	<parameter name="shell_timeout" unique="0" required="0">
+		<getopt mixed="--shell-timeout=[seconds]" />
+		<content type="second" default="3"  />
+		<shortdesc lang="en">Wait X seconds for cmd prompt after issuing command</shortdesc>
+	</parameter>
+	<parameter name="stonith_status_sleep" unique="0" required="0">
+		<getopt mixed="--stonith-status-sleep=[seconds]" />
+		<content type="second" default="1"  />
+		<shortdesc lang="en">Sleep X seconds between status calls during a STONITH action</shortdesc>
+	</parameter>
+	<parameter name="retry_on" unique="0" required="0">
+		<getopt mixed="--retry-on=[attempts]" />
+		<content type="integer" default="1"  />
+		<shortdesc lang="en">Count of attempts to retry power on</shortdesc>
+	</parameter>
+	<parameter name="telnet_path" unique="0" required="0">
+		<getopt mixed="--telnet-path=[path]" />
+		<shortdesc lang="en">Path to telnet binary</shortdesc>
+	</parameter>
+</parameters>
+<actions>
+	<action name="on" automatic="0"/>
+	<action name="off" />
+	<action name="reboot" />
+	<action name="status" />
+	<action name="list" />
+	<action name="list-status" />
+	<action name="monitor" />
+	<action name="metadata" />
+	<action name="manpage" />
+	<action name="validate-all" />
+</actions>
+</resource-agent>


### PR DESCRIPTION
This fence has been found in a really old Ubuntu fence-agents version
(distro precise from 2012) and was added by a separate tarball.
It has been re-worked to be compatible with latest fence-agents mainline
package, tested against a SENTRY power switch with firmware version 7.1a.

The original code has been written by Andres Rodriguez. Beside adding myself
with a recent copyright notice reflecting my changes, the original license
description on top of the sources (GPL) is untouched.

No idea why this never made it mainline, but I can confirm it convenient
and working with the HW I tested against.

Main credits for the original fence development go to:

CC: Andres Rodriguez <andres.rodriguez@canonical.com>