### PR TITLE
Mid: fence_sbd: A warning message is output when disable-timeout is enabled. 

### DIFF
--- a/agents/sbd/fence_sbd.py
+++ b/agents/sbd/fence_sbd.py
@@ -398,7 +398,7 @@ which can be used in environments where sbd can be used (shared storage)."
     # then that defined within sbd we should report this.
     power_timeout = int(options["--power-timeout"])
     sbd_msg_timeout = get_msg_timeout(options)
-    if power_timeout <= sbd_msg_timeout:
+    if 0 < power_timeout <= sbd_msg_timeout:
         logging.warn("power timeout needs to be \
                 greater then sbd message timeout")
 


### PR DESCRIPTION
Hi All,

This PR is a modified version of the next PR.
 - https://github.com/ClusterLabs/fence-agents/pull/420

Best Regards,
Hideoo Yamauchi.