### PR TITLE
fence_pve: Replace `nodename` with `pmx-node` in fence_pve.py (matching original intent)

### DIFF
--- a/tests/data/metadata/fence_pve.xml
+++ b/tests/data/metadata/fence_pve.xml
@@ -72,19 +72,29 @@
 		<shortdesc lang="en">Login name</shortdesc>
 	</parameter>
 	<parameter name="node_name" unique="0" required="0" deprecated="1">
-		<getopt mixed="-N, --nodename" />
+		<getopt mixed="--nodename" />
 		<content type="string"  />
-		<shortdesc lang="en">Node on which machine is located. (Optional, will be automatically determined)</shortdesc>
+		<shortdesc lang="en">Replaced by --pve-node</shortdesc>
 	</parameter>
 	<parameter name="nodename" unique="0" required="0" obsoletes="node_name">
-		<getopt mixed="-N, --nodename" />
+		<getopt mixed="--nodename" />
 		<content type="string"  />
-		<shortdesc lang="en">Node on which machine is located. (Optional, will be automatically determined)</shortdesc>
+		<shortdesc lang="en">Replaced by --pve-node</shortdesc>
+	</parameter>
+	<parameter name="pve_node" unique="0" required="0">
+		<getopt mixed="-N, --pve-node=[node_name]" />
+		<content type="string"  />
+		<shortdesc lang="en">Proxmox node name on which machine is located. (Must be specified if not using --pve-node-auto)</shortdesc>
 	</parameter>
 	<parameter name="vmtype" unique="0" required="1">
 		<getopt mixed="--vmtype" />
 		<content type="string" default="qemu"  />
 		<shortdesc lang="en">Virtual machine type lxc or qemu. (Default: qemu)</shortdesc>
+	</parameter>
+	<parameter name="pve_node_auto" unique="0" required="0">
+		<getopt mixed="-A, --pve-node-auto" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Automatically select proxmox node. (This option overrides --pve-node)</shortdesc>
 	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />

--- a/tests/data/metadata/fence_pve.xml
+++ b/tests/data/metadata/fence_pve.xml
@@ -71,6 +71,21 @@
 		<content type="string" default="root@pam"  />
 		<shortdesc lang="en">Login name</shortdesc>
 	</parameter>
+	<parameter name="pve_node" unique="0" required="0">
+		<getopt mixed="-N, --pve-node=[node_name]" />
+		<content type="string"  />
+		<shortdesc lang="en">Proxmox node name on which machine is located. (Must be specified if not using --pve-node-auto)</shortdesc>
+	</parameter>
+	<parameter name="pve_node_auto" unique="0" required="0">
+		<getopt mixed="-A, --pve-node-auto" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Automatically select proxmox node. (This option overrides --pve-node)</shortdesc>
+	</parameter>
+	<parameter name="vmtype" unique="0" required="1">
+		<getopt mixed="--vmtype" />
+		<content type="string" default="qemu"  />
+		<shortdesc lang="en">Virtual machine type lxc or qemu. (Default: qemu)</shortdesc>
+	</parameter>
 	<parameter name="node_name" unique="0" required="0" deprecated="1">
 		<getopt mixed="--nodename" />
 		<content type="string"  />
@@ -80,21 +95,6 @@
 		<getopt mixed="--nodename" />
 		<content type="string"  />
 		<shortdesc lang="en">Replaced by --pve-node</shortdesc>
-	</parameter>
-	<parameter name="pve_node" unique="0" required="0">
-		<getopt mixed="-N, --pve-node=[node_name]" />
-		<content type="string"  />
-		<shortdesc lang="en">Proxmox node name on which machine is located. (Must be specified if not using --pve-node-auto)</shortdesc>
-	</parameter>
-	<parameter name="vmtype" unique="0" required="1">
-		<getopt mixed="--vmtype" />
-		<content type="string" default="qemu"  />
-		<shortdesc lang="en">Virtual machine type lxc or qemu. (Default: qemu)</shortdesc>
-	</parameter>
-	<parameter name="pve_node_auto" unique="0" required="0">
-		<getopt mixed="-A, --pve-node-auto" />
-		<content type="boolean"  />
-		<shortdesc lang="en">Automatically select proxmox node. (This option overrides --pve-node)</shortdesc>
 	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />


### PR DESCRIPTION
refactor to suit original intent of internal `nodename` logic.

Change;
 * `pmx-node` option is used to specify the proxmox cluster node controlling the vm
 * `nodename` option indicates the "node to fence"

`fence_pve` relies on `plug` for node actions and never `nodename` - this is unchanged

Current behaviour;
If nodename is not provided to the fence agent, autodiscovery will fail during fencing activities.
 * The "watch/list" behaviours would execute correctly, (due to no nodename provided for those actions).
 * Status and all node-focused actions would fail due to nodename being the cluster node, not the proxmox node. ​

New behaviour;
 * ​If `pmx-node` is provided to the fence agent, it will use that node
 * ​if `pmx-node` is not provided to the fence agent, it will discover and set it correctly

This will break existing implementations that specify the node name - I'm open to suggestions for how to deal with that
