### PR TITLE
fence_kubevirt: make apiversion a parameter

### DIFF
--- a/tests/data/metadata/fence_kubevirt.xml
+++ b/tests/data/metadata/fence_kubevirt.xml
@@ -33,6 +33,11 @@
 		<content type="string"  />
 		<shortdesc lang="en">Kubeconfig file path</shortdesc>
 	</parameter>
+	<parameter name="apiversion" unique="0" required="0">
+		<getopt mixed="--apiversion=[apiversion]" />
+		<content type="string" default="kubevirt.io/v1"  />
+		<shortdesc lang="en">Version of the KubeVirt API.</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />


### PR DESCRIPTION
API_VERSION is right now hard coded to 'kubevirt.io/v1'. E.g. CNV
2.6.X still has v1alpha3. This introduce --apiversion parameter,
which defaults to 'kubevirt.io/v1', but still allows to set a
differen version if required.