### PR TITLE
fence_ibmz: add option --load-on-activate

### DIFF
--- a/agents/ibmz/fence_ibmz.py
+++ b/agents/ibmz/fence_ibmz.py
@@ -81,7 +81,10 @@ class APIClient(object):
         # default API port
         'port': 6794,
         # validate ssl certificates
-        'ssl_verify': False
+        'ssl_verify': False,
+        # load on activate is set in the HMC activation profile and therefore
+        # no additional load is executed by the fence agent
+        'load_on_activate': False
     }
     LABEL_BY_OP_MODE = {
         'classic': {
@@ -190,6 +193,8 @@ class APIClient(object):
                     'waiting for activate (timeout %s secs)', timeout)
                 self._wait_for_job('post', op_uri, job_resp['job-uri'],
                                    timeout=timeout)
+                if self._config['load_on_activate']:
+                    return
 
         # trigger the start job
         op_uri = '{}/operations/{}'.format(part_uri, label_map[action])
@@ -424,6 +429,7 @@ def set_opts():
         "read_retries",
         "read_timeout",
         "ssl_secure",
+        "load_on_activate",
     ]
 
     all_opt["ipport"]["default"] = APIClient.DEFAULT_CONFIG['port']
@@ -488,6 +494,14 @@ def set_opts():
         "shortdesc" : "How long to wait for server data",
         "order" : 2
     }
+    all_opt["load_on_activate"] = {
+        "getopt" : "",
+        "longopt" : "load-on-activate",
+        "help" : "--load-on-activate             Rely on the HMC to perform "
+                 "a load operation on activation",
+        "required" : "0",
+        "order" : 3
+    }
     return device_opt
 
 def main():
@@ -535,6 +549,7 @@ def main():
         'read_timeout': int(options['--read-timeout']),
         'port': int(options['--ipport']),
         'ssl_verify': bool('--ssl-secure' in options),
+        'load_on_activate': bool('--load-on-activate' in options),
     }
     try:
         conn = APIClient(hmc_address, hmc_userid, hmc_password, config)

--- a/tests/data/metadata/fence_ibmz.xml
+++ b/tests/data/metadata/fence_ibmz.xml
@@ -93,6 +93,11 @@
 		<content type="second" default="300"  />
 		<shortdesc lang="en">How long to wait for server data</shortdesc>
 	</parameter>
+	<parameter name="load_on_activate" unique="0" required="0">
+		<getopt mixed="--load-on-activate" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Rely on the HMC to perform a load operation on activation</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />


### PR DESCRIPTION
Add support for the "Load during activation" option for IBM Z. This
option let's a system administrator specify a load device from which the
LPAR is loaded automatically during activation.

If the fence agent is invoked with the --load-on-activate command line
argument, the API request for an explicit load operation is skipped,
ultimately relying on the configuration of the "Load during activation"
option in the activation profile.

Signed-off-by: Bjoern Walk <bwalk@linux.ibm.com>
Signed-off-by: Bodo Brand <bodo.brand1@ibm.com>