### PR TITLE
build: fix parallel build of lib/ vs agents/

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -22,6 +22,10 @@ rngdir			= ${CLUSTERDATA}/relaxng
 
 rng_DATA		= $(XSL) $(FASRNG)
 
+azure_fence.py: fencing.py
+fencing_snmp.py: fencing.py
+check_used_options.py: fencing.py
+
 include $(top_srcdir)/make/fencebuild.mk
 
 xml-check: all


### PR DESCRIPTION
the main problem is that automake does not really deal well
with dependencies between subdirs when doing parallel builds
with -j.

the simplest solution is to disable parallel build for, and only for,
the top level makefile.

this will force make to first dive into lib/ and then everything.

parallel builds of agents and doc will continue to work as expected

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>