### PR TITLE
fence_apc.py compatibility for Firmware major release 7 workaround #475

### DIFF
--- a/agents/apc/fence_apc.py
+++ b/agents/apc/fence_apc.py
@@ -250,7 +250,7 @@ will block any necessary fencing actions."
 	####
 	result = -1
 	firmware_version = re.compile(r'\s*v(\d)*\.').search(conn.before)
-	if (firmware_version != None) and (firmware_version.group(1) in [ "5", "6" ]):
+	if (firmware_version != None) and (firmware_version.group(1) in [ "5", "6", "7" ]):
 		result = fence_action(conn, options, set_power_status5, get_power_status5, get_power_status5)
 	else:
 		result = fence_action(conn, options, set_power_status, get_power_status, get_power_status)


### PR DESCRIPTION
#475 My bad, I accidentaly removed the last pull request. Since APC/Schneider Electric released major version 7 of the firmware, this is a workaround to keep the script using the "*5s" methods. The implementation seems to still work fine, but I did not perform extensive and detailed tests. Moreover a more robust and safe control on the major version number has to be considered.