### PR TITLE
PowerVS Modifications

### DIFF
--- a/agents/ibm_powervs/fence_ibm_powervs.py
+++ b/agents/ibm_powervs/fence_ibm_powervs.py
@@ -1,10 +1,11 @@
-#!@PYTHON@ -tt
+#!/usr/libexec/platform-python -tt
 
 import sys
 import pycurl, io, json
 import logging
 import atexit
-sys.path.append("@FENCEAGENTSLIBDIR@")
+import time
+sys.path.append("/usr/share/fence")
 from fencing import *
 from fencing import fail, run_delay, EC_LOGIN_DENIED, EC_STATUS
 
@@ -14,16 +15,30 @@ state = {
 	 "ERROR": "unknown"
 }
 
+def get_token(conn, options):
+
+        try:
+                command = "identity/token"
+                action = "grant_type=urn%3Aibm%3Aparams%3Aoauth%3Agrant-type%3Aapikey&apikey={}".format(options["--token"])
+                res = send_command(conn, command, "POST", action, printResult=False)
+        except Exception as e:
+                logging.debug("Failed: {}".format(e))
+                return "TOKEN_IS_MISSING_OR_WRONG"
+
+        #if "--verbose" in options:
+        #        logging.debug(json.dumps(res, indent=2))
+
+        return res["access_token"]
+
 def get_list(conn, options):
 	outlets = {}
-
+	
 	try:
 		command = "cloud-instances/{}/pvm-instances".format(options["--instance"])
 		res = send_command(conn, command)
 	except Exception as e:
 		logging.debug("Failed: {}".format(e))
 		return outlets
-
 	for r in res["pvmInstances"]:
 		if "--verbose" in options:
 			logging.debug(json.dumps(r, indent=2))
@@ -32,6 +47,7 @@ def get_list(conn, options):
 	return outlets
 
 def get_power_status(conn, options):
+
 	try:
 		command = "cloud-instances/{}/pvm-instances/{}".format(
 				options["--instance"], options["--plug"])
@@ -40,10 +56,11 @@ def get_power_status(conn, options):
 	except KeyError as e:
 		logging.debug("Failed: Unable to get status for {}".format(e))
 		fail(EC_STATUS)
-
+	
 	return result
 
 def set_power_status(conn, options):
+
 	action = {
 		"on" :  '{"action" : "start"}',
 		"off" : '{"action" : "immediate-shutdown"}',
@@ -56,24 +73,52 @@ def set_power_status(conn, options):
 		logging.debug("Failed: Unable to set power to {} for {}".format(options["--action"], e))
 		fail(EC_STATUS)
 
-def connect(opt):
+def connect(opt, token):
 	conn = pycurl.Curl()
 
 	## setup correct URL
-	conn.base_url = "https://" + opt["--region"] + ".power-iaas.cloud.ibm.com/pcloud/v1/"
+	conn.base_url = "https://private." + opt["--region"] + ".power-iaas.cloud.ibm.com/pcloud/v1/"
+	if opt["--api-type"] == "public":
+		conn.base_url = "https://" + opt["--region"] + ".power-iaas.cloud.ibm.com/pcloud/v1/"
 
 	if opt["--verbose-level"] > 1:
-		conn.setopt(pycurl.VERBOSE, 1)
+		conn.setopt(pycurl.VERBOSE, 0)
 
+	conn.setopt(pycurl.CONNECTTIMEOUT,int(opt["--shell-timeout"]))
 	conn.setopt(pycurl.TIMEOUT, int(opt["--shell-timeout"]))
 	conn.setopt(pycurl.SSL_VERIFYPEER, 1)
 	conn.setopt(pycurl.SSL_VERIFYHOST, 2)
+	conn.setopt(pycurl.PROXY, "{}".format(opt["--proxy"]))
 
 	# set auth token for later requests
 	conn.setopt(pycurl.HTTPHEADER, [
 		"Content-Type: application/json",
-		"Authorization: Bearer {}".format(opt["--token"]),
+		"Authorization: Bearer {}".format(token),
 		"CRN: {}".format(opt["--crn"]),
+		"User-Agent: curl",
+	])
+	
+	return conn
+
+def auth_connect(opt):
+	conn = pycurl.Curl()
+
+	# setup correct URL
+	conn.base_url = "https://iam.cloud.ibm.com/"
+
+	if opt["--verbose-level"] > 1:
+		conn.setopt(pycurl.VERBOSE, 1)
+
+	conn.setopt(pycurl.CONNECTTIMEOUT,int(opt["--shell-timeout"]))
+	conn.setopt(pycurl.TIMEOUT, int(opt["--shell-timeout"]))
+	conn.setopt(pycurl.SSL_VERIFYPEER, 1)
+	conn.setopt(pycurl.SSL_VERIFYHOST, 2)
+	conn.setopt(pycurl.PROXY, "{}".format(opt["--proxy"]))
+
+	# set auth token for later requests
+	conn.setopt(pycurl.HTTPHEADER, [
+		"Content-type: application/x-www-form-urlencoded",
+		"Accept: application/json",
 		"User-Agent: curl",
 	])
 
@@ -82,9 +127,9 @@ def connect(opt):
 def disconnect(conn):
 	conn.close()
 
-def send_command(conn, command, method="GET", action=None):
+def send_command(conn, command, method="GET", action=None, printResult=True):
 	url = conn.base_url + command
-
+	
 	conn.setopt(pycurl.URL, url.encode("ascii"))
 
 	web_buffer = io.BytesIO()
@@ -99,8 +144,10 @@ def send_command(conn, command, method="GET", action=None):
 	conn.setopt(pycurl.WRITEFUNCTION, web_buffer.write)
 
 	try:
+		time.sleep(3)
 		conn.perform()
 	except Exception as e:
+		logging.error("ADD_DEBUG: {}".format(e))
 		raise(e)
 
 	rc = conn.getinfo(pycurl.HTTP_CODE)
@@ -110,8 +157,7 @@ def send_command(conn, command, method="GET", action=None):
 
 	if rc != 200:
 		if len(result) > 0:
-			raise Exception("{}: {}".format(rc,
-					result["value"]["messages"][0]["default_message"]))
+			raise Exception("{}: {}".format(rc,result))
 		else:
 			raise Exception("Remote returned {} for request to {}".format(rc, url))
 
@@ -121,7 +167,8 @@ def send_command(conn, command, method="GET", action=None):
 	logging.debug("url: {}".format(url))
 	logging.debug("method: {}".format(method))
 	logging.debug("response code: {}".format(rc))
-	logging.debug("result: {}\n".format(result))
+	if printResult:
+		logging.debug("result: {}\n".format(result))
 
 	return result
 
@@ -129,9 +176,9 @@ def define_new_opts():
 	all_opt["token"] = {
 		"getopt" : ":",
 		"longopt" : "token",
-		"help" : "--token=[token]                Bearer Token",
+		"help" : "--token=[token]                API Token",
 		"required" : "1",
-		"shortdesc" : "Bearer Token",
+		"shortdesc" : "API Token",
 		"order" : 0
 	}
 	all_opt["crn"] = {
@@ -158,6 +205,22 @@ def define_new_opts():
 		"shortdesc" : "Region",
 		"order" : 0
 	}
+	all_opt["api-type"] = {
+                "getopt" : ":",
+                "longopt" : "api-type",
+                "help" : "--api-type=[private|public]          API-type: 'private' (default) or 'public'",
+                "required" : "0",
+                "shortdesc" : "API-type (private|public)",
+                "order" : 0
+        }
+	all_opt["proxy"] = {
+                "getopt" : ":",
+                "longopt" : "proxy",
+                "help" : "--proxy=[http://<URL>:<PORT>]          Proxy: 'http://<URL>:<PORT>'",
+                "required" : "0",
+                "shortdesc" : "Network proxy",
+                "order" : 0
+        }
 
 
 def main():
@@ -166,6 +229,8 @@ def main():
 		"crn",
 		"instance",
 		"region",
+		"api-type",
+		"proxy",
 		"port",
 		"no_password",
 	]
@@ -173,9 +238,11 @@ def main():
 	atexit.register(atexit_handler)
 	define_new_opts()
 
-	all_opt["shell_timeout"]["default"] = "15"
+	all_opt["shell_timeout"]["default"] = "500"
 	all_opt["power_timeout"]["default"] = "30"
 	all_opt["power_wait"]["default"] = "1"
+	all_opt["api-type"]["default"] = "private"
+	all_opt["proxy"]["default"] = ""
 
 	options = check_input(device_opt, process_input(device_opt))
 
@@ -190,8 +257,11 @@ used with IBM PowerVS to fence virtual machines."""
 	## Fence operations
 	####
 	run_delay(options)
-
-	conn = connect(options)
+	
+	auth_conn = auth_connect(options)
+	token = get_token(auth_conn, options)
+	disconnect(auth_conn)
+	conn = connect(options, token)
 	atexit.register(disconnect, conn)
 
 	result = fence_action(conn, options, set_power_status, get_power_status, get_list)


### PR DESCRIPTION
- Added support for API key instead of programmatic token. Token itself is requested with API key.
- Added support for private and public API URIs (default is private)
- Added support for proxy server
- Introduced 2s delay before every API call

Successful verifications:

- 24 hours run in pacemaker
- "pcs stonith fence z2.example.com"
- usr/sbin/fence_ibm_powervs --token='***' --crn='crn:v1:bluemix:public:power-iaas:dal12:a/cc523990bee44147bfcbbe43a9a9838c:313b3fa6-55e0-4661-bb55-544e47561e00::' --instance=313b3fa6-55e0-4661-bb55-544e47561e00 --region=us-south --plug=268156d0-2d85-4ac5-9050-7fa60c282eb1 --proxy=http://192.168.150.4:3128 -o list --separator=':' --debug /root/debug
- /usr/sbin/fence_ibm_powervs --token='****' --crn='crn:v1:bluemix:public:power-iaas:dal12:a/cc523990bee44147bfcbbe43a9a9838c:313b3fa6-55e0-4661-bb55-544e47561e00::' --instance=313b3fa6-55e0-4661-bb55-544e47561e00 --region=us-south --plug=71565aa2-e3e9-43cd-9ee7-710e86aedb32 --proxy=http://192.168.150.4:3128 -o off --separator=':'
- /usr/sbin/fence_ibm_powervs --token='****' --crn='crn:v1:bluemix:public:power-iaas:dal12:a/cc523990bee44147bfcbbe43a9a9838c:313b3fa6-55e0-4661-bb55-544e47561e00::' --instance=313b3fa6-55e0-4661-bb55-544e47561e00 --region=us-south --plug=71565aa2-e3e9-43cd-9ee7-710e86aedb32 --proxy=http://192.168.150.4:3128 -o on --separator=':'