### PR TITLE
Mid: fence_scsi,fence_mpath: Add suppress-errors option.

### DIFF
--- a/agents/mpath/fence_mpath.py
+++ b/agents/mpath/fence_mpath.py
@@ -197,7 +197,8 @@ def mpath_check(hardreboot=False):
 		logging.getLogger().setLevel(logging.DEBUG)
 	devs = dev_read(options, fail=False)
 	if not devs:
-		logging.error("No devices found")
+		if "--suppress-errors" not in options:
+			logging.error("No devices found")
 		return 0
 	for dev, key in list(devs.items()):
 		for n in range(int(options["retry"]) + 1):
@@ -237,6 +238,14 @@ Each device must support SCSI-3 persistent reservations.",
 		"shortdesc" : "Replaced by port/-n/--plug",
 		"order": 1
 	}
+	all_opt["suppress-errors"] = {
+		"getopt" : "",
+		"longopt" : "suppress-errors",
+		"help" : "--suppress-errors              Suppress error log. Suppresses error logging when run from the watchdog service before pacemaker starts.",
+		"required" : "0",
+		"shortdesc" : "Error log suppression.",
+		"order": 4
+        }
 	all_opt["mpathpersist_path"] = {
 		"getopt" : ":",
 		"longopt" : "mpathpersist-path",
@@ -261,7 +270,7 @@ def main():
 
 	device_opt = ["no_login", "no_password", "devices", "key", "sudo", \
 	        "fabric_fencing", "on_target", "store_path", \
-		"mpathpersist_path", "force_on", "port", "no_port"]
+		"suppress-errors", "mpathpersist_path", "force_on", "port", "no_port"]
 
 	define_new_opts()
 

--- a/agents/scsi/fence_scsi.py
+++ b/agents/scsi/fence_scsi.py
@@ -270,12 +270,13 @@ def dev_write(dev, options):
 	f.close()
 
 
-def dev_read(fail=True):
+def dev_read(fail=True, opt=None):
 	file_path = STORE_PATH + ".dev"
 	try:
 		f = open(file_path, "r")
 	except IOError:
-		fail_usage("Failed: Cannot open file \"" + file_path + "\"", fail)
+		if "--suppress-errors" not in opt:
+			fail_usage("Failed: Cannot open file \"" + file_path + "\"", fail)
 		if not fail:
 			return None
 	# get not empty lines from file
@@ -358,13 +359,21 @@ be removed from the device(s).",
 		"shortdesc" : "Open DEVICE read-only.",
 		"order": 4
 	}
+	all_opt["suppress-errors"] = {
+		"getopt" : "",
+		"longopt" : "suppress-errors",
+		"help" : "--suppress-errors              Suppress error log. Suppresses error logging when run from the watchdog service before pacemaker starts.",
+		"required" : "0",
+		"shortdesc" : "Error log suppression.",
+		"order": 5
+	}
 	all_opt["logfile"] = {
 		"getopt" : ":",
 		"longopt" : "logfile",
 		"help" : "-f, --logfile                  Log output (stdout and stderr) to file",
 		"required" : "0",
 		"shortdesc" : "Log output (stdout and stderr) to file",
-		"order": 5
+		"order": 6
 	}
 	all_opt["corosync_cmap_path"] = {
 		"getopt" : ":",
@@ -445,9 +454,10 @@ def scsi_check(hardreboot=False):
 	options = scsi_check_get_options(options)
 	if "verbose" in options and options["verbose"] == "yes":
 		logging.getLogger().setLevel(logging.DEBUG)
-	devs = dev_read(fail=False)
+	devs = dev_read(fail=False,opt=options)
 	if not devs:
-		logging.error("No devices found")
+		if "--suppress-errors" not in options:
+			logging.error("No devices found")
 		return 0
 	key = get_key(fail=False)
 	if not key:
@@ -480,7 +490,7 @@ def main():
 
 	device_opt = ["no_login", "no_password", "devices", "nodename", "port",\
 	"no_port", "key", "aptpl", "fabric_fencing", "on_target", "corosync_cmap_path",\
-	"sg_persist_path", "sg_turs_path", "readonly", "logfile", "vgs_path",\
+	"sg_persist_path", "sg_turs_path", "readonly", "suppress-errors", "logfile", "vgs_path",\
 	"force_on", "key_value"]
 
 	define_new_opts()

--- a/tests/data/metadata/fence_mpath.xml
+++ b/tests/data/metadata/fence_mpath.xml
@@ -31,6 +31,16 @@ When used as a watchdog device you can define e.g. retry=1, retry-sleep=2 and ve
 		<content type="string"  />
 		<shortdesc lang="en">Key to use for the current operation. This key should be unique to a node and have to be written in /etc/multipath.conf. For the "on" action, the key specifies the key use to register the local node. For the "off" action, this key specifies the key to be removed from the device(s).</shortdesc>
 	</parameter>
+	<parameter name="suppress-errors" unique="0" required="0" deprecated="1">
+		<getopt mixed="--suppress-errors" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Error log suppression.</shortdesc>
+	</parameter>
+	<parameter name="suppress_errors" unique="0" required="0" obsoletes="suppress-errors">
+		<getopt mixed="--suppress-errors" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Error log suppression.</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />
@@ -80,11 +90,6 @@ When used as a watchdog device you can define e.g. retry=1, retry-sleep=2 and ve
 		<getopt mixed="--login-timeout=[seconds]" />
 		<content type="second" default="5"  />
 		<shortdesc lang="en">Wait X seconds for cmd prompt after login</shortdesc>
-	</parameter>
-	<parameter name="suppress_errors" unique="0" required="0" obsoletes="suppress-errors">
-		<getopt mixed="--suppress-errors"/>
-		<content type="boolean"/>
-		<shortdesc lang="en">Error log suppression.</shortdesc>
 	</parameter>
 	<parameter name="mpathpersist_path" unique="0" required="0">
 		<getopt mixed="--mpathpersist-path=[path]" />

--- a/tests/data/metadata/fence_mpath.xml
+++ b/tests/data/metadata/fence_mpath.xml
@@ -81,6 +81,11 @@ When used as a watchdog device you can define e.g. retry=1, retry-sleep=2 and ve
 		<content type="second" default="5"  />
 		<shortdesc lang="en">Wait X seconds for cmd prompt after login</shortdesc>
 	</parameter>
+	<parameter name="suppress_errors" unique="0" required="0" obsoletes="suppress-errors">
+		<getopt mixed="--suppress-errors"/>
+		<content type="boolean"/>
+		<shortdesc lang="en">Error log suppression.</shortdesc>
+	</parameter>
 	<parameter name="mpathpersist_path" unique="0" required="0">
 		<getopt mixed="--mpathpersist-path=[path]" />
 		<shortdesc lang="en">Path to mpathpersist binary</shortdesc>

--- a/tests/data/metadata/fence_scsi.xml
+++ b/tests/data/metadata/fence_scsi.xml
@@ -41,9 +41,14 @@ When used as a watchdog device you can define e.g. retry=1, retry-sleep=2 and ve
 		<content type="boolean"  />
 		<shortdesc lang="en">Open DEVICE read-only.</shortdesc>
 	</parameter>
+	<parameter name="suppress-errors" unique="0" required="0" deprecated="1">
+		<getopt mixed="--suppress-errors" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Error log suppression.</shortdesc>
+	</parameter>
 	<parameter name="suppress_errors" unique="0" required="0" obsoletes="suppress-errors">
-		<getopt mixed="--suppress-errors"/>
-		<content type="boolean"/>
+		<getopt mixed="--suppress-errors" />
+		<content type="boolean"  />
 		<shortdesc lang="en">Error log suppression.</shortdesc>
 	</parameter>
 	<parameter name="logfile" unique="0" required="0">

--- a/tests/data/metadata/fence_scsi.xml
+++ b/tests/data/metadata/fence_scsi.xml
@@ -41,6 +41,11 @@ When used as a watchdog device you can define e.g. retry=1, retry-sleep=2 and ve
 		<content type="boolean"  />
 		<shortdesc lang="en">Open DEVICE read-only.</shortdesc>
 	</parameter>
+	<parameter name="suppress_errors" unique="0" required="0" obsoletes="suppress-errors">
+		<getopt mixed="--suppress-errors"/>
+		<content type="boolean"/>
+		<shortdesc lang="en">Error log suppression.</shortdesc>
+	</parameter>
 	<parameter name="logfile" unique="0" required="0">
 		<getopt mixed="-f, --logfile" />
 		<content type="string"  />


### PR DESCRIPTION
Hi Oyvind,
Hi All, 

This fix fixes the issue presented in the next issue.
 - https://github.com/ClusterLabs/fence-agents/issues/482

Add --suppress-errors to /etc/sysconfig/stonith to suppress the logs output when used with the watchdog service.

Best Regards,
Hideo Yamauchi.