### PR TITLE
Fence virtd groups

### DIFF
--- a/agents/virt/common/log.c
+++ b/agents/virt/common/log.c
@@ -159,7 +159,9 @@ void
 __wrap_closelog(void)
 {
 	struct log_entry *lent;
+#ifdef DEBUG
 	int lost = 0;
+#endif
 
 	if (thread_id != 0) {
 		pthread_cancel(thread_id);
@@ -168,7 +170,9 @@ __wrap_closelog(void)
 	}
 	__real_closelog();
 	while (_log_entries) {
+#ifdef DEBUG
 		++lost;
+#endif
 		lent = _log_entries;
 		list_remove(&_log_entries, lent);
 		free(lent->message);

--- a/agents/virt/fence_virtd.service.in
+++ b/agents/virt/fence_virtd.service.in
@@ -6,7 +6,6 @@ Documentation=man:fence_virt.conf(5)
 After=basic.target
 After=network.target
 After=syslog.target
-After=libvirt-qmf.service
 After=libvirtd.service
 After=corosync.service
 

--- a/agents/virt/include/static_map.h
+++ b/agents/virt/include/static_map.h
@@ -2,7 +2,7 @@
 #define _STATIC_MAP_H
 
 typedef int (*map_load_t)(void *config, void **perm_info);
-typedef int (*map_check_t)(void *info, const char *src, const char *tgt);
+typedef int (*map_check_t)(void *info, const char *src, const char *tgt_uuid, const char *tgt_name);
 typedef void (*map_cleanup_t)(void **info);
 
 typedef struct {
@@ -17,8 +17,10 @@ typedef struct {
  */
 #define map_load(obj, config) \
 	obj->load(config, &obj->info)
-#define map_check(obj, src, tgt) \
-	obj->check(obj->info, src, tgt)
+#define map_check(obj, src, tgt_uuid) \
+	obj->check(obj->info, src, tgt_uuid, NULL)
+#define map_check2(obj, src, tgt_uuid, tgt_name) \
+	obj->check(obj->info, src, tgt_uuid, tgt_name)
 #define map_free(obj) \
 	obj->cleanup(obj->info)
 

--- a/agents/virt/man/fence_virt.conf.5
+++ b/agents/virt/man/fence_virt.conf.5
@@ -124,7 +124,8 @@ libvirt domain description.  Note that only type
 .B unix
 , mode 
 .B bind
-serial ports and channels are supported.  Example libvirt XML:
+serial ports and channels are supported and each VM should have a
+separate unique socket.  Example libvirt XML:
 
 .in 8
   <\fBserial\fP type='unix'>
@@ -140,7 +141,7 @@ serial ports and channels are supported.  Example libvirt XML:
 .TP
 .B uri
 .
-the URI to use when connecting to libvirt by the serial plugin.
+the URI to use when connecting to libvirt by the serial plugin (optional).
 
 .TP
 .B path
@@ -281,6 +282,8 @@ redability and debugging of configuration parsing.
 .
 Defines UUID as a member of a group.  It can be used multiple times
 to specify both node name and UUID values that can be fenced.
+When using the serial listener in serial mode (/dev/ttyS1), the vm uuid
+is required and it is recommeded to add also the vm name.
 
 .TP
 .B ip
@@ -292,7 +295,8 @@ the group.  It is highly recommended that this be used in conjunction
 with a key file.
 When using the vsock listener, ip should contain the CID value assigned
 by libvirt to the vm.
-
+When using the serial listener in serial mode (/dev/ttyS1), ip value
+is not used and can be omitted.
 
 
 .SH EXAMPLE

--- a/agents/virt/man/fence_virt.conf.5
+++ b/agents/virt/man/fence_virt.conf.5
@@ -282,8 +282,8 @@ redability and debugging of configuration parsing.
 .
 Defines UUID as a member of a group.  It can be used multiple times
 to specify both node name and UUID values that can be fenced.
-When using the serial listener in serial mode (/dev/ttyS1), the vm uuid
-is required and it is recommeded to add also the vm name.
+When using the serial listener, the vm uuid is required and it is
+recommeded to add also the vm name.
 
 .TP
 .B ip
@@ -295,8 +295,7 @@ the group.  It is highly recommended that this be used in conjunction
 with a key file.
 When using the vsock listener, ip should contain the CID value assigned
 by libvirt to the vm.
-When using the serial listener in serial mode (/dev/ttyS1), ip value
-is not used and can be omitted.
+When using the serial listener, ip value is not used and can be omitted.
 
 
 .SH EXAMPLE

--- a/agents/virt/man/fence_virt.conf.5
+++ b/agents/virt/man/fence_virt.conf.5
@@ -290,6 +290,8 @@ for members of this group (e.g. for multicast).  It can be used
 multiple times to allow more than 1 IP to send fencing requests to
 the group.  It is highly recommended that this be used in conjunction
 with a key file.
+When using the vsock listener, ip should contain the CID value assigned
+by libvirt to the vm.
 
 
 

--- a/agents/virt/man/fence_virt.conf.5
+++ b/agents/virt/man/fence_virt.conf.5
@@ -302,6 +302,12 @@ groups if desired.
 This defines a group.
 
 .TP
+.B name
+.
+Optinally define the name of the group. Useful only for configuration
+redability and debugging of configuration parsing.
+
+.TP
 .B uuid
 .
 Defines UUID as a member of a group.  It can be used multiple times
@@ -341,6 +347,7 @@ with a key file.
  
  groups {
   group {
+   name = "cluster1";
    ip = "192.168.1.1";
    ip = "192.168.1.2";
    uuid = "44179d3f-6c63-474f-a212-20c8b4b25b16";

--- a/agents/virt/man/fence_virt.conf.5
+++ b/agents/virt/man/fence_virt.conf.5
@@ -239,37 +239,6 @@ of the URI.
 
 Example: qemu:///session?socket=/run/user/<UID>/libvirt/virtqemud-sock
 
-.SS libvirt-qmf
-
-The libvirt-qmf plugin acts as a QMFv2 Console to the libvirt-qmf daemon in
-order to route fencing requests over AMQP to the appropriate computer.
-
-.TP
-.B host
-.
-host or IP address of qpid broker.  Defaults to 127.0.0.1.
-
-.TP
-.B port
-.
-IP port of qpid broker.  Defaults to 5672.
-
-.TP
-.B username
-.
-Username for GSSAPI, if configured.
-
-.TP
-.B service
-.
-Qpid service to connect to.
-
-.TP
-.B gssapi
-.
-If set to 1, have fence_virtd use GSSAPI for authentication when communicating
-with the Qpid broker.  Default is 0 (off).
-
 .SS cpg
 
 The cpg plugin uses corosync CPG and libvirt to track virtual

--- a/agents/virt/server/Makefile.am
+++ b/agents/virt/server/Makefile.am
@@ -32,7 +32,7 @@ fence_virtd_LDADD		= $(VIRT_CONFIG_LIBS) $(VIRT_COMMON_LIBS) \
 fence_virtd_LDFLAGS		= $(VIRT_AM_LDFLAGS) $(VIRT_COMMON_LDFLAGS)
 
 virt_la_SOURCES			= libvirt.c virt.c uuid-test.c
-cpg_la_SOURCES			= cpg-virt.c cpg.c virt.c
+cpg_la_SOURCES			= cpg-virt.c cpg.c virt.c uuid-test.c
 multicast_la_SOURCES		= mcast.c history.c
 tcp_la_SOURCES			= tcp.c history.c
 vsock_la_SOURCES		= vsock.c history.c

--- a/agents/virt/server/mcast.c
+++ b/agents/virt/server/mcast.c
@@ -61,7 +61,7 @@
 #include "history.h"
 
 #define NAME "multicast"
-#define MCAST_VERSION "1.2"
+#define MCAST_VERSION "1.3"
 
 #define MCAST_MAGIC 0xabb911a3
 
@@ -192,7 +192,7 @@ mcast_hostlist(const char *vm_name, const char *vm_uuid,
 	struct timeval tv;
 	int ret;
 
-	if (map_check(arg->map, arg->src, vm_uuid) == 0) {
+	if (map_check2(arg->map, arg->src, vm_uuid, vm_name) == 0) {
 		/* if we don't have access to fence this VM,
 		 * we should not see it in a hostlist either */
 		return 0;

--- a/agents/virt/server/serial.c
+++ b/agents/virt/server/serial.c
@@ -58,7 +58,7 @@
 #include "xvm.h"
 
 #define NAME "serial"
-#define SERIAL_VERSION "0.4"
+#define SERIAL_VERSION "0.5"
 
 #define SERIAL_PLUG_MAGIC 0x1227a000
 
@@ -118,7 +118,7 @@ serial_hostlist(const char *vm_name, const char *vm_uuid,
 	struct timeval tv;
 	int ret;
 
-	if (map_check(arg->map, arg->src, vm_uuid) == 0) {
+	if (map_check2(arg->map, arg->src, vm_uuid, vm_name) == 0) {
 		/* if we don't have access to fence this VM,
 		 * we should not see it in a hostlist either */
 		return 0;

--- a/agents/virt/server/serial.c
+++ b/agents/virt/server/serial.c
@@ -356,7 +356,7 @@ serial_config(config_object_t *config, serial_info *args)
 
 	if (sc_get(config, "listeners/serial/@path",
 		   value, sizeof(value)-1) == 0) {
-		dbg_printf(1, "Got %s for uri\n", value);
+		dbg_printf(1, "Got %s for path\n", value);
 		args->path = strdup(value);
 	} 
 

--- a/agents/virt/server/static_map.c
+++ b/agents/virt/server/static_map.c
@@ -65,6 +65,8 @@ static_map_check(void *info, const char *src, const char *tgt_uuid, const char *
 	if (!info)
 		return 1; /* no maps == wide open */
 
+	dbg_printf(99, "[server:map_check] map request: src: %s uuid: %s name: %s\n", src, tgt_uuid, tgt_name);
+
 	uuid = is_uuid(src);
 
 	list_for(&groups, group, x) {

--- a/agents/virt/server/static_map.c
+++ b/agents/virt/server/static_map.c
@@ -55,7 +55,7 @@ static_map_cleanup(void **info)
 
 
 static int
-static_map_check(void *info, const char *value1, const char *value2)
+static_map_check(void *info, const char *src, const char *tgt_uuid, const char *tgt_name)
 {
 	struct perm_group *groups = (struct perm_group *)info;
 	struct perm_group *group;
@@ -65,21 +65,21 @@ static_map_check(void *info, const char *value1, const char *value2)
 	if (!info)
 		return 1; /* no maps == wide open */
 
-	uuid = is_uuid(value1);
+	uuid = is_uuid(src);
 
 	list_for(&groups, group, x) {
 		left = NULL;
 
 		if (uuid) {
 			list_for(&group->uuids, tmp, y) {
-				if (!strcasecmp(tmp->name, value1)) {
+				if (!strcasecmp(tmp->name, src)) {
 					left = tmp;
 					break;
 				}
 			}
 		} else {
 			list_for(&group->ips, tmp, y) {
-				if (!strcasecmp(tmp->name, value1)) {
+				if (!strcasecmp(tmp->name, src)) {
 					left = tmp;
 					break;
 				}
@@ -90,8 +90,14 @@ static_map_check(void *info, const char *value1, const char *value2)
 			continue;
 
 		list_for(&group->uuids, tmp, y) {
-			if (!strcasecmp(tmp->name, value2)) {
+			if (!strcasecmp(tmp->name, tgt_uuid)) {
 				return 1;
+			}
+			/* useful only for list */
+			if (tgt_name) {
+				if (!strcasecmp(tmp->name, tgt_name)) {
+					return 1;
+				}
 			}
 		}
 	}

--- a/agents/virt/server/static_map.c
+++ b/agents/virt/server/static_map.c
@@ -128,8 +128,11 @@ static_map_load(void *config_ptr, void **perm_info)
 					break;
 				}
 			}
-			snprintf(value, sizeof(value), "unnamed-%d",
-				 group_idx);
+			snprintf(buf2, sizeof(buf2)-1, "%s/@name", buf);
+			if (sc_get(config, buf2, value, sizeof(value)) != 0) {
+				snprintf(value, sizeof(value), "unnamed-%d",
+					 group_idx);
+			}
 		}
 
 		group = malloc(sizeof(*group));

--- a/agents/virt/server/tcp.c
+++ b/agents/virt/server/tcp.c
@@ -27,6 +27,8 @@
 #include <signal.h>
 #include <errno.h>
 #include <nss.h>
+#include <sys/socket.h>
+#include <netdb.h>
 
 /* Local includes */
 #include "xvm.h"
@@ -163,9 +165,18 @@ tcp_hostlist_end(int fd)
 	return 1;
 }
 
+static socklen_t
+sockaddr_len(const struct sockaddr_storage *ss)
+{
+	if (ss->ss_family == AF_INET) {
+		return sizeof(struct sockaddr_in);
+	} else {
+		return sizeof(struct sockaddr_in6);
+	}
+}
 
 static int
-do_fence_request_tcp(int fd, fence_req_t *req, tcp_info *info)
+do_fence_request_tcp(int fd, struct sockaddr_storage *ss, socklen_t sock_len, fence_req_t *req, tcp_info *info)
 {
 	char ip_addr_src[1024];
 	char response = 1;
@@ -186,8 +197,18 @@ do_fence_request_tcp(int fd, fence_req_t *req, tcp_info *info)
 		return -1;
 	}
 
-	dbg_printf(2, "Request %d seqno %d target %s\n", 
-		   req->request, req->seqno, req->domain);
+
+	if (getnameinfo((struct sockaddr *)ss, sockaddr_len(ss),
+			ip_addr_src, sizeof(ip_addr_src),
+			NULL, 0,
+			NI_NUMERICHOST | NI_NUMERICSERV) < 0) {
+		printf("Unable to resolve!\n");
+		close(fd);
+		return -1;
+	}
+
+	dbg_printf(2, "Request %d seqno %d src %s target %s\n",
+		   req->request, req->seqno, ip_addr_src, req->domain);
 
 	switch(req->request) {
 	case FENCE_NULL:
@@ -267,6 +288,8 @@ tcp_dispatch(listener_context_t c, struct timeval *timeout)
 	int client_fd;
     int ret;
 	struct timeval tv;
+	struct sockaddr_storage ss;
+	socklen_t sock_len = sizeof(ss);
 
     if (timeout != NULL)
     	memcpy(&tv, timeout, sizeof(tv));
@@ -290,7 +313,7 @@ tcp_dispatch(listener_context_t c, struct timeval *timeout)
 		return n;
 	}
 	
-	client_fd = accept(info->listen_sock, NULL, NULL);
+	client_fd = accept(info->listen_sock, (struct sockaddr *)&ss, &sock_len);
 	if (client_fd < 0) {
 		perror("accept");
 		return -1;
@@ -329,7 +352,7 @@ tcp_dispatch(listener_context_t c, struct timeval *timeout)
 	case AUTH_SHA256:
 	case AUTH_SHA512:
 		printf("Plain TCP request\n");
-		do_fence_request_tcp(client_fd, &data, info);
+		do_fence_request_tcp(client_fd, &ss, sock_len, &data, info);
 		break;
 	default:
 		printf("XXX Unhandled authentication\n");

--- a/agents/virt/server/tcp.c
+++ b/agents/virt/server/tcp.c
@@ -44,7 +44,7 @@
 #include "history.h"
 
 #define NAME "tcp"
-#define TCP_VERSION "0.1"
+#define TCP_VERSION "0.2"
 
 #define TCP_MAGIC 0xc3dff7a9
 
@@ -113,7 +113,7 @@ tcp_hostlist(const char *vm_name, const char *vm_uuid,
 	struct timeval tv;
 	int ret;
 
-	if (map_check(arg->map, arg->src, vm_uuid) == 0) {
+	if (map_check2(arg->map, arg->src, vm_uuid, vm_name) == 0) {
 		/* if we don't have access to fence this VM,
 		 * we should not see it in a hostlist either */
 		return 0;

--- a/agents/virt/server/vsock.c
+++ b/agents/virt/server/vsock.c
@@ -45,7 +45,7 @@
 #include "fdops.h"
 
 #define NAME "vsock"
-#define VSOCK_VERSION "0.1"
+#define VSOCK_VERSION "0.2"
 
 #define VSOCK_MAGIC 0xa32d27c1e
 
@@ -145,7 +145,7 @@ vsock_hostlist(const char *vm_name, const char *vm_uuid,
 
 	/* Noops if auth == AUTH_NONE */
 
-	if (map_check(arg->map, peer_cid_str, vm_uuid) == 0) {
+	if (map_check2(arg->map, peer_cid_str, vm_uuid, vm_name) == 0) {
 		/* if we don't have access to fence this VM,
 		 * we should not see it in a hostlist either */
 		return 0;

--- a/fence-agents.spec.in
+++ b/fence-agents.spec.in
@@ -193,9 +193,8 @@ sed -i.orig 's|FENCE_ZVM=1|FENCE_ZVM=0|' configure.ac
 %{configure} \
 %if %{defined _tmpfilesdir}
 	SYSTEMD_TMPFILES_DIR=%{_tmpfilesdir} \
-	--with-fencetmpdir=/run/fence-agents \
+	--with-fencetmpdir=/run/fence-agents
 %endif
-	--disable-libvirt-qmf-plugin
 
 CFLAGS="$(echo '%{optflags}')" make %{_smp_mflags}
 


### PR DESCRIPTION
Tested with both libvirt and cpg backends.
Tested with mcast, tcp, vsock and serial listeners.

NOTE: the serial listener has both "serial" and "vmchannel" mode. I was able to test only "serial" mode as vmchannel requires a libvirt managed bridge for intercepting TCP connections and I don´t have that setup.

Updated man page for group based on all different setups.

Resolves: https://github.com/ClusterLabs/fence-agents/issues/515