### PR TITLE
fence_amt/fence_ipmilan/fence_ironic: use shlex instead of pipes when available, as pipes is deprecated and will be removed in Python 3.13

### DIFF
--- a/agents/amt/fence_amt.py
+++ b/agents/amt/fence_amt.py
@@ -2,10 +2,14 @@
 
 import sys, re, os
 import atexit
-from pipes import quote
 sys.path.append("@FENCEAGENTSLIBDIR@")
 from fencing import *
 from fencing import fail_usage, is_executable, run_command, run_delay
+
+try:
+	from shlex import quote
+except ImportError:
+	from pipes import quote
 
 def get_power_status(_, options):
 	output = amt_run_command(options, create_command(options, "status"))

--- a/agents/ipmilan/fence_ipmilan.py
+++ b/agents/ipmilan/fence_ipmilan.py
@@ -2,10 +2,14 @@
 
 import sys, re, os
 import atexit
-from pipes import quote
 sys.path.append("@FENCEAGENTSLIBDIR@")
 from fencing import *
 from fencing import fail_usage, is_executable, run_command, run_delay
+
+try:
+	from shlex import quote
+except ImportError:
+	from pipes import quote
 
 def get_power_status(_, options):
 	output = _run_command(options, "status")

--- a/agents/ironic/fence_ironic.py
+++ b/agents/ironic/fence_ironic.py
@@ -5,10 +5,14 @@ import logging
 import os
 import re
 import sys
-from pipes import quote
 sys.path.append("@FENCEAGENTSLIBDIR@")
 from fencing import *
 from fencing import fail_usage, is_executable, run_command, run_delay
+
+try:
+	from shlex import quote
+except ImportError:
+	from pipes import quote
 
 def get_name_or_uuid(options):
 	return options["--uuid"] if "--uuid" in options else options["--plug"]


### PR DESCRIPTION
https://docs.python.org/3/library/pipes.html