### PR TITLE
fence_gce: add earlyexit parameter to power_cycle_instance

### DIFF
--- a/agents/gce/fence_gce.py
+++ b/agents/gce/fence_gce.py
@@ -304,6 +304,9 @@ def power_cycle_instance(conn, options, instance, zone):
 			operation = retry_api_execute(
 					options,
 					conn.instances().reset(project=project, zone=zone, instance=instance))
+			if operation and "--earlyexit" in options:
+				logging.info("Reset command sent, returning early and not waiting for the operation to complete")
+				return True
 		logging.info("Reset command sent, waiting for the operation to complete")
 		if wait_for_operation(conn, options, zone, operation):
 			logging.info("Reset of %s in zone %s complete", instance, zone)
@@ -454,8 +457,8 @@ def define_new_opts():
 	all_opt["earlyexit"] = {
 		"getopt" : "",
 		"longopt" : "earlyexit",
-		"help" : "--earlyexit                    Return early if reset is already in progress",
-		"shortdesc" : "If an existing reset operation is detected, the fence agent will return before the operation completes with a 0 return code.",
+		"help" : "--earlyexit                    Return early from set_power_status if reset is already in progress, if power_cycle then do not wait for the reset",
+		"shortdesc" : "If running set_power_status and existing reset operation is detected or runnning power_cycle, the fence agent will return before the operation completes with a 0 return code.",
 		"required" : "0",
 		"order" : 13
 	}

--- a/tests/data/metadata/fence_gce.xml
+++ b/tests/data/metadata/fence_gce.xml
@@ -91,7 +91,7 @@ For instructions see: https://cloud.google.com/compute/docs/tutorials/python-gui
 	<parameter name="earlyexit" unique="0" required="0">
 		<getopt mixed="--earlyexit" />
 		<content type="boolean"  />
-		<shortdesc lang="en">If an existing reset operation is detected, the fence agent will return before the operation completes with a 0 return code.</shortdesc>
+		<shortdesc lang="en">If running set_power_status and existing reset operation is detected or runnning power_cycle, the fence agent will return before the operation completes with a 0 return code.</shortdesc>
 	</parameter>
 	<parameter name="warntimeout" unique="0" required="0">
 		<getopt mixed="--warntimeout=[warn_timeout]" />


### PR DESCRIPTION
If earlyexit is enabled then power_cycle will exit before the execution of the power cycle on the gce instance is complete.