### PR TITLE
Update fence_vmware_soap.py

### DIFF
--- a/agents/vmware_soap/fence_vmware_soap.py
+++ b/agents/vmware_soap/fence_vmware_soap.py
@@ -204,6 +204,7 @@ def set_power_status(conn, options):
 			if options["--action"] == "on":
 				fail(EC_WAITING_ON)
 			else:
+				print(ex)
 				fail(EC_WAITING_OFF)
 
 def remove_tmp_dir(tmp_dir):


### PR DESCRIPTION
Detailed error message on VM shutdown failure. The original value, "EC_WAITING_OFF" alone can be misleading. 