### PR TITLE
fence_azure_arm: fix get virtual machines call

### DIFF
--- a/agents/azure_arm/fence_azure_arm.py
+++ b/agents/azure_arm/fence_azure_arm.py
@@ -72,7 +72,7 @@ def get_power_status(clients, options):
 
         powerState = "unknown"
         try:
-            vmStatus = compute_client.virtual_machines.get(rgName, vmName, "instanceView")
+            vmStatus = compute_client.virtual_machines.get(rgName, vmName, expand="instanceView")
         except Exception as e:
             fail_usage("Failed: %s" % e)
 


### PR DESCRIPTION
Problem:

The `fence_azure_arm`  script shows the following error: 
```sh
VirtualMachinesOperations.get() takes 3 positional arguments but 4 were given
```

Explanation:

The function virtual_machines.get() has changed its signature from:

```python
def get(
    self,
    resource_group_name,
    expand=None,
    **kwargs
):
```
to:

```python
def get(
    self,
    resource_group_name: str,
    machine_name: str,
    expand: Optional[Union[str, _models.InstanceViewTypes]] = None,
    **kwargs: Any
    ) -> _models.Machine:
```

Therefore, the number of positional arguments has been reduced to two: `resource_group_name` and `machine_name`, while the `expand` parameter has swift from a *positional argument* to a *keyword-only argument*: https://github.com/Azure/azure-sdk-for-python/pull/27590/files#diff-d5feb43fb2e32f16f624d64917b3fa784cc7ea829373fcd49dc09a9a36e46f56L105

Fix: https://github.com/Azure/azure-sdk-for-python/issues/30983

All credit to @msyyc who originally posted the solution to this issue in: https://github.com/Azure/azure-sdk-for-python/issues/30983#issuecomment-1647081509