### PR TITLE
fence_ovm: Replace all_opt "ssl_client_cert_file" with "ssl_client_certificate_file"

### DIFF
--- a/agents/ovm/fence_ovm.py
+++ b/agents/ovm/fence_ovm.py
@@ -127,7 +127,7 @@ def send_command(connection, options, resources_path, method="GET"):
 	return result
 
 def define_new_opts():
-	all_opt["ssl_client_cert_file"] = {
+	all_opt["ssl_client_certificate_file"] = {
 		"getopt" : ":",
 		"longopt" : "ssl-client-certificate-file",
 		"help" : "--ssl-client-certificate-file=[filename]   SSL client certificate file",
@@ -158,7 +158,7 @@ def validate_input(opt, stop=True):
 	return valid_input
 
 def main():
-	device_opt = ["ipaddr", "ipport", "login", "no_login", "passwd", "no_password", "port", "ssl", "ssl_client_cert_file"]
+	device_opt = ["ipaddr", "ipport", "login", "no_login", "passwd", "no_password", "port", "ssl", "ssl_client_certificate_file"]
 
 	atexit.register(atexit_handler)
 

--- a/tests/data/metadata/fence_ovm.xml
+++ b/tests/data/metadata/fence_ovm.xml
@@ -63,11 +63,7 @@
 		<content type="boolean"  />
 		<shortdesc lang="en">Use SSL connection with verifying certificate</shortdesc>
 	</parameter>
-	<parameter name="ssl_client_cert_file" unique="0" required="0" deprecated="1">
-		<getopt mixed="--ssl-client-certificate-file=[filename]" />
-		<shortdesc lang="en">SSL client certificate file</shortdesc>
-	</parameter>
-	<parameter name="ssl_client_certificate_file" unique="0" required="0" obsoletes="ssl_client_cert_file">
+	<parameter name="ssl_client_certificate_file" unique="0" required="0">
 		<getopt mixed="--ssl-client-certificate-file=[filename]" />
 		<shortdesc lang="en">SSL client certificate file</shortdesc>
 	</parameter>


### PR DESCRIPTION
This PR is in response to https://github.com/ClusterLabs/fence-agents/pull/565#discussion_r1374182284.

Replace "ssl_client_cert_file" with "ssl_client_certificate_file".