### PR TITLE
fence_vmware_rest: monitoring action is not detecting if the API user has sufficient right to manage the fence device.

### DIFF
--- a/agents/vmware_rest/fence_vmware_rest.py
+++ b/agents/vmware_rest/fence_vmware_rest.py
@@ -60,6 +60,9 @@ def get_list(conn, options):
 		else:
 			fail(EC_STATUS)
 
+	if options.get("--original-action") == "monitor" and not res["value"]:
+		logging.error("API user does not have sufficient rights to manage the power status.")
+		fail(EC_STATUS)
 	for r in res["value"]:
 		outlets[r["name"]] = ("", state[r["power_state"]])
 


### PR DESCRIPTION
The call https://{api_host}/api/vcenter/vm is subject to permission checks. If the delivered list is empty the user has no rights.