### PR TITLE
fence_docker: Connect to Docker via a UNIX socket

### DIFF
--- a/agents/docker/fence_docker.py
+++ b/agents/docker/fence_docker.py
@@ -48,6 +48,8 @@ def send_cmd(options, cmd, post = False):
 	output_buffer = io.BytesIO()
 	if logging.getLogger().getEffectiveLevel() < logging.WARNING:
 		conn.setopt(pycurl.VERBOSE, True)
+	if "--unix-socket" in options:
+		conn.setopt(pycurl.UNIX_SOCKET_PATH, options["--unix-socket"])
 	conn.setopt(pycurl.HTTPGET, 1)
 	conn.setopt(pycurl.URL, url.encode("ascii"))
 	if post:
@@ -135,11 +137,34 @@ TLS authentication.  Required if --ssl option is used.",
 		"default" : "1.11",
 	}
 
-	device_opt = ["ipaddr", "no_password", "no_login", "port", "method", "web", "tlscert", "tlskey", "tlscacert", "ssl", "api_version"]
+	all_opt["unix_socket"] = {
+		"getopt" : ":",
+		"longopt" : "unix-socket",
+		"help" : "--unix-socket                  "
+			"Path to Docker's unix socket. Use this with --disable-ssl.",
+		"required" : "0",
+		"order" : 2,
+	}
 
+	all_opt["disable_ssl"] = {
+		"getopt" : "",
+		"longopt" : "disable-ssl",
+		"help" : "--disable-ssl                  Don't use SSL connection",
+		"required" : "0",
+		"shortdesc" : "Don't use SSL",
+		"order": 2,
+	}
+
+	device_opt = ["ipaddr", "no_password", "no_login", "port", "method", "web",
+		"tlscert", "tlskey", "tlscacert", "ssl", "api_version", "unix_socket",
+		"disable_ssl"]
 	all_opt["ssl"]["default"] = "1"
-
 	options = check_input(device_opt, process_input(device_opt))
+
+	if "--disable-ssl" in options or options["--ssl"] == "0":
+		for k in ["--ssl", "--ssl-secure", "--ssl-insecure"]:
+			if k in options:
+				del options[k]
 
 	docs = { }
 	docs["shortdesc"] = "Fence agent for Docker"

--- a/tests/data/metadata/fence_docker.xml
+++ b/tests/data/metadata/fence_docker.xml
@@ -61,6 +61,11 @@
 		<content type="string" default="1.11"  />
 		<shortdesc lang="en">Version of Docker Remote API (default: 1.11)</shortdesc>
 	</parameter>
+	<parameter name="disable_ssl" unique="0" required="0">
+		<getopt mixed="--disable-ssl" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Don't use SSL</shortdesc>
+	</parameter>
 	<parameter name="tlscacert" unique="0" required="0">
 		<getopt mixed="--tlscacert" />
 		<content type="string"  />
@@ -75,6 +80,11 @@
 		<getopt mixed="--tlskey" />
 		<content type="string"  />
 		<shortdesc lang="en">Path to client key (PEM format) for TLS authentication.  Required if --ssl option is used.</shortdesc>
+	</parameter>
+	<parameter name="unix_socket" unique="0" required="0">
+		<getopt mixed="--unix-socket" />
+		<content type="string"  />
+		<shortdesc lang="en">Path to Docker's unix socket. Use this with --disable-ssl.</shortdesc>
 	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />


### PR DESCRIPTION
With this change we extend the Docker connection options to connect via a UNIX socket. To do so we add a new command line argument --unix-socket which expects the path to the Docker socket.

Also in order for this to make sense we disable the default setting of the SSL verification.

Closes #581
Closes #582