### PR TITLE
Mid: fence_mpath: Allow reservation_key in multipath.conf to be the same as reservation_key in pcmk_host_map.

### DIFF
--- a/agents/mpath/fence_mpath.py
+++ b/agents/mpath/fence_mpath.py
@@ -332,6 +332,7 @@ failing."
 		fail_usage("Failed: No devices found")
 
 	options["devices"] = [d for d in re.split(r"\s*,\s*|\s+", options["--devices"].strip()) if d]
+	options["--plug"] = re.sub(r'^0+', '', re.sub(r"^0x", "", options["--plug"]))
 	# Input control END
 
 	result = fence_action(None, options, set_status, get_status)


### PR DESCRIPTION
Hi All,

Currently, fence_mpath may not work if you specify the same mapping key as the multipath.conf setting.
```
(If it works)
multipath.conf - reservation_key 0x1
pcmk_host_map - "nodeA:1"
(If it does not work)
multipath.conf - reservation_key 0x1
pcmk_host_map - "nodeA:0x1"
```

This fix converts the key specified in pcmk_host_map passed by pacemaker so that both allow the same key (hexadecimal).

This fix makes unfencing/fencing possible in both cases presented above, reducing the number of mistakes users make in setting pcmk_host_map.



Best Regards,
Hideo Yamauchi.
