### PR TITLE
azure-fence.py: use azure-identity instead of msrestazure as it has been deprecated

### DIFF
--- a/agents/azure_arm/fence_azure_arm.py
+++ b/agents/azure_arm/fence_azure_arm.py
@@ -183,7 +183,7 @@ def define_new_opts():
         "getopt" : ":",
         "longopt" : "cloud",
         "help" : "--cloud=[name]                 Name of the cloud you want to use. Supported\n\
-                                  values are china, germany, usgov, or stack. Do\n\
+                                  values are china, usgov, or stack. Do\n\
                                   not use this parameter if you want to use\n\
                                   public Azure.",
         "shortdesc" : "Name of the cloud you want to use.",

--- a/lib/azure_fence.py.py
+++ b/lib/azure_fence.py.py
@@ -273,18 +273,18 @@ def get_azure_config(options):
 def get_azure_cloud_environment(config):
     cloud_environment = None
     if config.Cloud:
-	try:
-	    from azure.identity import AzureAuthorityHosts
+        try:
+            from azure.identity import AzureAuthorityHosts
             if (config.Cloud.lower() == "china"):
-	        cloud_environment = AzureAuthorityHosts.AZURE_CHINA
+                cloud_environment = AzureAuthorityHosts.AZURE_CHINA
             elif (config.Cloud.lower() == "usgov"):
-	        cloud_environment = AzureAuthorityHosts.AZURE_GOVERNMENT
+                cloud_environment = AzureAuthorityHosts.AZURE_GOVERNMENT
             elif (config.Cloud.lower() == "stack"):
-	        cloud_environment = get_cloud_from_metadata_endpoint(config.MetadataEndpoint)
-	except ImportError:
+                cloud_environment = get_cloud_from_metadata_endpoint(config.MetadataEndpoint)
+        except ImportError:
             if (config.Cloud.lower() == "china"):
-                 from msrestazure.azure_cloud import AZURE_CHINA_CLOUD
-                 cloud_environment = AZURE_CHINA_CLOUD
+                from msrestazure.azure_cloud import AZURE_CHINA_CLOUD
+                cloud_environment = AZURE_CHINA_CLOUD
             elif (config.Cloud.lower() == "germany"):
                 from msrestazure.azure_cloud import AZURE_GERMAN_CLOUD
                 cloud_environment = AZURE_GERMAN_CLOUD

--- a/lib/azure_fence.py.py
+++ b/lib/azure_fence.py.py
@@ -273,18 +273,27 @@ def get_azure_config(options):
 def get_azure_cloud_environment(config):
     cloud_environment = None
     if config.Cloud:
-        if (config.Cloud.lower() == "china"):
-            from msrestazure.azure_cloud import AZURE_CHINA_CLOUD
-            cloud_environment = AZURE_CHINA_CLOUD
-        elif (config.Cloud.lower() == "germany"):
-            from msrestazure.azure_cloud import AZURE_GERMAN_CLOUD
-            cloud_environment = AZURE_GERMAN_CLOUD
-        elif (config.Cloud.lower() == "usgov"):
-            from msrestazure.azure_cloud import AZURE_US_GOV_CLOUD
-            cloud_environment = AZURE_US_GOV_CLOUD
-        elif (config.Cloud.lower() == "stack"):
-            from msrestazure.azure_cloud import get_cloud_from_metadata_endpoint
-            cloud_environment = get_cloud_from_metadata_endpoint(config.MetadataEndpoint)
+	try:
+	    from azure.identity import AzureAuthorityHosts
+            if (config.Cloud.lower() == "china"):
+	        cloud_environment = AzureAuthorityHosts.AZURE_CHINA
+            elif (config.Cloud.lower() == "usgov"):
+	        cloud_environment = AzureAuthorityHosts.AZURE_GOVERNMENT
+            elif (config.Cloud.lower() == "stack"):
+	        cloud_environment = get_cloud_from_metadata_endpoint(config.MetadataEndpoint)
+	except ImportError:
+            if (config.Cloud.lower() == "china"):
+                 from msrestazure.azure_cloud import AZURE_CHINA_CLOUD
+                 cloud_environment = AZURE_CHINA_CLOUD
+            elif (config.Cloud.lower() == "germany"):
+                from msrestazure.azure_cloud import AZURE_GERMAN_CLOUD
+                cloud_environment = AZURE_GERMAN_CLOUD
+            elif (config.Cloud.lower() == "usgov"):
+                from msrestazure.azure_cloud import AZURE_US_GOV_CLOUD
+                cloud_environment = AZURE_US_GOV_CLOUD
+            elif (config.Cloud.lower() == "stack"):
+                from msrestazure.azure_cloud import get_cloud_from_metadata_endpoint
+                cloud_environment = get_cloud_from_metadata_endpoint(config.MetadataEndpoint)
 
     return cloud_environment
 


### PR DESCRIPTION
Implementing cloud environment setup with azure.identy