### PR TITLE
fence_lpar: Add "Error" in the list of on states

### DIFF
--- a/agents/lpar/fence_lpar.py
+++ b/agents/lpar/fence_lpar.py
@@ -20,7 +20,7 @@ from fencing import fail, fail_usage, EC_STATUS_HMC
 ##
 ## Transformation to standard ON/OFF status if possible
 def _normalize_status(status):
-	if status in ["Running", "Open Firmware", "Shutting Down", "Starting"]:
+	if status in ["Running", "Open Firmware", "Shutting Down", "Starting", "Error"]:
 		status = "on"
 	else:
 		status = "off"


### PR DESCRIPTION
When the LPAR crashes it can stay in Error state.

It's not possible to transition to 'Running' state from 'Error' but it's possible to power off the LPAR. Then for all parctical purposes 'Error' is an on state.

Fixes: #610