### PR TITLE
fence_compute/fence_evacuate: dont use deprecated inspect.getargspec()

### DIFF
--- a/agents/compute/fence_compute.py
+++ b/agents/compute/fence_compute.py
@@ -285,7 +285,7 @@ def create_nova_connection(options):
 
 	nova_versions = [ "2.11", "2" ]
 	for version in nova_versions:
-		clientargs = inspect.getargspec(client.Client).varargs
+		clientargs = inspect.getfullargspec(client.Client).varargs
 		# Some versions of Openstack prior to Ocata only
 		# supported positional arguments for username,
 		# password, and tenant.

--- a/agents/evacuate/fence_evacuate.py
+++ b/agents/evacuate/fence_evacuate.py
@@ -221,7 +221,7 @@ def create_nova_connection(options):
 
 	versions = [ "2.11", "2" ]
 	for version in versions:
-		clientargs = inspect.getargspec(client.Client).varargs
+		clientargs = inspect.getfullargspec(client.Client).varargs
 
 		# Some versions of Openstack prior to Ocata only
 		# supported positional arguments for username,


### PR DESCRIPTION
/usr/sbin/fence_compute:288: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()