### PR TITLE
fence_sbd: Add crashdump option

### DIFF
--- a/agents/sbd/fence_sbd.py
+++ b/agents/sbd/fence_sbd.py
@@ -228,10 +228,12 @@ def reboot_cycle(conn, options):
 
     plug = options["--plug"]
     return_code = 99
+    enable_crashdump = "--crashdump" in options
     out = ""
     err = ""
 
-    (return_code, out, err) = send_sbd_message(conn, options, plug, "reset")
+    msg = "crashdump" if enable_crashdump else "reset"
+    (return_code, out, err) = send_sbd_message(conn, options, plug, msg)
     return not bool(return_code)
 
 def get_power_status(conn, options):

--- a/tests/data/metadata/fence_sbd.xml
+++ b/tests/data/metadata/fence_sbd.xml
@@ -114,6 +114,11 @@
 		<content type="second" default="1"  />
 		<shortdesc lang="en">Sleep X seconds between status calls during a STONITH action</shortdesc>
 	</parameter>
+	<parameter name="crashdump" unique="0" required="0">
+		<getopt mixed="--crashdump" />
+		<content type="boolean"  />
+		<shortdesc lang="en">Crashdump instead of regular fence</shortdesc>
+	</parameter>
 	<parameter name="retry_on" unique="0" required="0">
 		<getopt mixed="--retry-on=[attempts]" />
 		<content type="integer" default="1"  />


### PR DESCRIPTION
The parameter tells fence agent to message a "crashdump" poison pill rather than "reset/off" through sbd device.

Following the logic from https://github.com/ClusterLabs/sbd/blob/main/agent/sbd.in#L76-L79