### PR TITLE
fence_aws: Add new skip_os_shutdown flag

### DIFF
--- a/tests/data/metadata/fence_aws.xml
+++ b/tests/data/metadata/fence_aws.xml
@@ -52,8 +52,8 @@ For instructions see: https://boto3.readthedocs.io/en/latest/guide/quickstart.ht
 		<shortdesc lang="en">Skip race condition check</shortdesc>
 	</parameter>
 	<parameter name="skip_os_shutdown" unique="0" required="0">
-		<getopt mixed="-k, --skip-os-shutdown=[on|off]" />
-		<content type="string" default="off"  />
+		<getopt mixed="--skip-os-shutdown=[true|false]" />
+		<content type="string" default="true"  />
 		<shortdesc lang="en">Use SkipOsShutdown flag to stop the EC2 instance</shortdesc>
 	</parameter>
 	<parameter name="quiet" unique="0" required="0">


### PR DESCRIPTION
This change introduces a new feature flag to ```fence_aws``` agent to incorporate the new SkipOsShutdown feature.
- https://aws.amazon.com/about-aws/whats-new/2025/07/amazon-ec2-skip-os-shutdown-option-during-stop-terminate/

Using this feature significantly reduces an EC2 instance stop times by skipping the graceful Operating System shutdown.

An example on using this flag to setup ```fence_aws```:

```
pcs stonith create <resource-name> fence_aws \
region=<aws-region> \
skip_os_shutdown=on \    -----> NEW FEATURE
pcmk_host_map="<primary-hostname>:<primary-instance-id>;<secondary-hostname>:<secondary-instance-id>" \ 
pcmk_delay_max=45 \ 
power_timeout=600 
pcmk_reboot_timeout=600 \ 
pcmk_reboot_retries=4 \ 
op start timeout=600 \ 
op monitor interval=300 timeout=60 
```

Alternatively, testing via command line:
```
fence_aws -n i-abcdefg1234567890 -o off --skip-os-shutdown on
```

This feature requires the following libraries:
- boto3 >= 1.39.12
- botocore >= 1.39.12

