### PR TITLE
fencing.py: change from Bash "source" to POSIX-compliant "."

### DIFF
--- a/lib/fencing.py.py
+++ b/lib/fencing.py.py
@@ -1274,7 +1274,7 @@ def fence_logout(conn, logout_string, sleep=0):
 
 def source_env(env_file):
     # POSIX: name shall not contain '=', value doesn't contain '\0'
-    output = subprocess.check_output("source {} && env -0".format(env_file), shell=True,
+    output = subprocess.check_output(". {} && env -0".format(env_file), shell=True,
                           executable="/bin/sh")
     # replace env
     os.environ.clear()


### PR DESCRIPTION
In the source_env function, the Bash-specific "source command is used, but the executable is defined as "/bin/sh", which in many systems may not evaluate to Bash. A PR exists to address this [1] by ensuring "/bin/bash" is the executable used, but the reviewer request to implement a more POSIX-compliant approach and not require Bash on the system seems to be unanswered for a couple years. This tiny PR would do just that.

[1] https://github.com/ClusterLabs/fence-agents/pull/547