### PR TITLE
fence_openstack: add auth-plugin support for clouds.yaml

### DIFF
--- a/agents/openstack/fence_openstack.py
+++ b/agents/openstack/fence_openstack.py
@@ -299,9 +299,7 @@ def main():
     all_opt["port"]["shortdesc"] = "UUID of the node to be fenced."
     all_opt["power_timeout"]["default"] = "60"
 
-    input_options = process_input(device_opt)
-    auth_plugin_provided = "--auth-plugin" in input_options
-    options = check_input(device_opt, input_options)
+    options = check_input(device_opt, process_input(device_opt))
 
     # workaround to avoid regressions
     if "--uuid" in options:
@@ -329,7 +327,7 @@ This agent calls the python-novaclient and it is mandatory to be installed "
     auth_options = None
     if options.get("--cloud"):
         cloud = get_cloud(options)
-        if not auth_plugin_provided:
+        if options["--auth-plugin"] == "password":
             options["--auth-plugin"] = cloud.get("auth_type") or options["--auth-plugin"]
         if options["--auth-plugin"] != "password":
             auth_options = cloud.get("auth")

--- a/agents/openstack/fence_openstack.py
+++ b/agents/openstack/fence_openstack.py
@@ -113,7 +113,8 @@ def set_power_status(conn, options):
 
 
 def nova_login(username, password, projectname, auth_url, user_domain_name,
-               project_domain_name, ssl_insecure, cacert, apitimeout):
+               project_domain_name, ssl_insecure, cacert, apitimeout,
+               auth_plugin="password", auth_options=None):
     legacy_import = False
 
     try:
@@ -131,16 +132,20 @@ def nova_login(username, password, projectname, auth_url, user_domain_name,
             fail_usage("Failed: Keystone client not found or not accessible")
 
     if not legacy_import:
-        loader = loading.get_plugin_loader("password")
-        auth = loader.load_from_options(
-            auth_url=auth_url,
-            username=username,
-            password=password,
-            project_name=projectname,
-            user_domain_name=user_domain_name,
-            project_domain_name=project_domain_name,
-        )
+        loader = loading.get_plugin_loader(auth_plugin)
+        if auth_options is None:
+            auth_options = dict(
+                auth_url=auth_url,
+                username=username,
+                password=password,
+                project_name=projectname,
+                user_domain_name=user_domain_name,
+                project_domain_name=project_domain_name,
+            )
+        auth = loader.load_from_options(**auth_options)
     else:
+        if auth_plugin != "password":
+            fail_usage("Failed: Keystone auth plugins require keystoneauth1")
         auth = v3.Password(
             auth_url=auth_url,
             username=username,
@@ -251,6 +256,15 @@ def define_new_opts():
         "default": 60,
         "order": 10,
     }
+    all_opt["auth-plugin"] = {
+        "getopt": ":",
+        "longopt": "auth-plugin",
+        "help": "--auth-plugin=[plugin]         Keystone auth plugin",
+        "required": "0",
+        "shortdesc": "Keystone auth plugin",
+        "default": "password",
+        "order": 11,
+    }
 
 
 def main():
@@ -265,6 +279,7 @@ def main():
         "project-name",
         "user-domain-name",
         "project-domain-name",
+        "auth-plugin",
         "cloud",
         "openrc",
         "port",
@@ -284,7 +299,9 @@ def main():
     all_opt["port"]["shortdesc"] = "UUID of the node to be fenced."
     all_opt["power_timeout"]["default"] = "60"
 
-    options = check_input(device_opt, process_input(device_opt))
+    input_options = process_input(device_opt)
+    auth_plugin_provided = "--auth-plugin" in input_options
+    options = check_input(device_opt, input_options)
 
     # workaround to avoid regressions
     if "--uuid" in options:
@@ -309,8 +326,13 @@ This agent calls the python-novaclient and it is mandatory to be installed "
 
     run_delay(options)
 
+    auth_options = None
     if options.get("--cloud"):
         cloud = get_cloud(options)
+        if not auth_plugin_provided:
+            options["--auth-plugin"] = cloud.get("auth_type") or options["--auth-plugin"]
+        if options["--auth-plugin"] != "password":
+            auth_options = cloud.get("auth")
         username = cloud.get("auth").get("username")
         password = cloud.get("auth").get("password")
         projectname = cloud.get("auth").get("project_name")
@@ -368,6 +390,8 @@ This agent calls the python-novaclient and it is mandatory to be installed "
             ssl_insecure,
             cacert,
             apitimeout,
+            options["--auth-plugin"],
+            auth_options,
         )
     except Exception as e:
         fail_usage("Failed: Unable to connect to Nova: " + str(e))

--- a/tests/data/metadata/fence_openstack.xml
+++ b/tests/data/metadata/fence_openstack.xml
@@ -118,6 +118,16 @@
 		<content type="second" default="60"  />
 		<shortdesc lang="en">Timeout in seconds to use for API calls, default is 60.</shortdesc>
 	</parameter>
+	<parameter name="auth-plugin" unique="0" required="0" deprecated="1">
+		<getopt mixed="--auth-plugin=[plugin]" />
+		<content type="string" default="password"  />
+		<shortdesc lang="en">Keystone auth plugin</shortdesc>
+	</parameter>
+	<parameter name="auth_plugin" unique="0" required="0" obsoletes="auth-plugin">
+		<getopt mixed="--auth-plugin=[plugin]" />
+		<content type="string" default="password"  />
+		<shortdesc lang="en">Keystone auth plugin</shortdesc>
+	</parameter>
 	<parameter name="quiet" unique="0" required="0">
 		<getopt mixed="-q, --quiet" />
 		<content type="boolean"  />


### PR DESCRIPTION
## Summary

`fence_openstack` currently forces the Keystone `password` auth plugin, including when credentials are read from `clouds.yaml`.

This change adds an `--auth-plugin` option, defaulting to `password`, and allows `clouds.yaml` `auth_type` / `auth` values to be used for non-password keystoneauth plugins such as `v3applicationcredential`.

## Motivation

In federated OpenStack environments, users may not have local Keystone passwords. Application credentials are a common non-interactive authentication mechanism for automation and HA/fencing tools.

## Compatibility

The default remains `password`, so existing username/password behavior is preserved.

This PR intentionally keeps the scope small:
- no openrc behavior changes
- no SSL/cacert behavior changes
- no unrelated refactoring

## Testing

- `python -m py_compile agents/openstack/fence_openstack.py`: passed
- `./autogen.sh` / `./configure` / `make`: not completed locally on macOS; `configure` failed because Apple linker does not support `-Wl,--enable-new-dtags`