### PR TITLE
fence_kubevirt: report Succeeded and Failed as OFF

### DIFF
--- a/agents/kubevirt/fence_kubevirt.py
+++ b/agents/kubevirt/fence_kubevirt.py
@@ -65,8 +65,11 @@ def get_power_status(conn, options):
         fail(EC_STATUS)
 
 def translate_status(instance_status):
+    logging.debug(f"translate_status(): {instance_status}")
     if instance_status == "Running":
         return "on"
+    elif instance_status in ["Succeeded", "Failed"]:
+        return "off"
     return "unknown"
 
 def set_power_status(conn, options):


### PR DESCRIPTION
With specific settings like RunStrategy: Manual and
failure to start up or manual shutdown from within,
the VMI object may exist while the VM is not running,
and it needs to be correctly parsed to provide the
right VM status.