### PR TITLE
fence_openstack: implement reboot_cycle_fn for hard reboot support

### DIFF
--- a/agents/openstack/fence_openstack.py
+++ b/agents/openstack/fence_openstack.py
@@ -112,19 +112,15 @@ def set_power_status(conn, options):
         except Conflict as e:
             fail_usage(e)
         logging.info("Called stop API call for " + server.id)
-    if action == "reboot":
-        logging.info("Rebooting instance " + server.name)
-        try:
-            server.reboot("HARD")
-        except Conflict as e:
-            fail_usage(e)
-        logging.info("Called reboot hard API call for " + server.id)
 
 
 def reboot_cycle(conn, options):
     server = conn.servers.get(options["--plug"])
     logging.info("Hard rebooting instance " + server.name)
-    server.reboot("HARD")
+    try:
+        server.reboot("HARD")
+    except Conflict as e:
+        fail_usage(e)
     logging.info("Called reboot HARD API call for " + server.id)
     return True
 

--- a/agents/openstack/fence_openstack.py
+++ b/agents/openstack/fence_openstack.py
@@ -121,6 +121,14 @@ def set_power_status(conn, options):
         logging.info("Called reboot hard API call for " + server.id)
 
 
+def reboot_cycle(conn, options):
+    server = conn.servers.get(options["--plug"])
+    logging.info("Hard rebooting instance " + server.name)
+    server.reboot("HARD")
+    logging.info("Called reboot HARD API call for " + server.id)
+    return True
+
+
 def nova_login(username, password, projectname, auth_url, user_domain_name,
                project_domain_name, ssl_insecure, cacert, apitimeout,
                auth_plugin="password", auth_options=None):
@@ -297,6 +305,7 @@ def main():
         "ssl_insecure",
         "cacert",
         "apitimeout",
+        "method",
     ]
 
     atexit.register(atexit_handler)
@@ -404,7 +413,7 @@ This agent calls the python-novaclient and it is mandatory to be installed "
         fail_usage("Failed: Unable to connect to Nova: " + str(e))
 
     # Operate the fencing device
-    result = fence_action(conn, options, set_power_status, get_power_status, get_nodes_list)
+    result = fence_action(conn, options, set_power_status, get_power_status, get_nodes_list, reboot_cycle_fn=reboot_cycle)
     sys.exit(result)
 
 


### PR DESCRIPTION
fence_openstack has server.reboot("HARD") code in set_power_status but it is never reached because the fencing framework decomposes the reboot action into off + poll + on before calling set_power_status. Implement reboot_cycle_fn and pass it to fence_action so that when method=cycle is configured, the agent calls Nova hard reboot API directly.